### PR TITLE
[PEAUTY-92] Divide progress step into 3 way

### DIFF
--- a/peauty-domain/src/main/java/com/peauty/domain/grooming/GroomingBiddingProcess.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/grooming/GroomingBiddingProcess.java
@@ -60,11 +60,6 @@ public class GroomingBiddingProcess {
         return newProcess;
     }
 
-    public void cancel() {
-        validateProcessStatus();
-        changeStatus(GroomingBiddingProcessStatus.CANCELED);
-    }
-
     public void addNewThread(DesignerId targetDesignerId) {
         validateProcessStatus();
         checkThreadAlreadyInProcess(targetDesignerId);
@@ -73,38 +68,53 @@ public class GroomingBiddingProcess {
         this.threads.add(newThread);
     }
 
-    public void progressThreadStep(GroomingBiddingThread.ID targetThreadId) {
+    public void cancel() {
         validateProcessStatus();
-        GroomingBiddingThread thread = getThreadByThreadId(targetThreadId);
-        thread.progressStep();
+        changeStatus(GroomingBiddingProcessStatus.CANCELED);
     }
 
-    public void progressThreadStep(DesignerId targetThreadDesignerId) {
-        validateProcessStatus();
-        GroomingBiddingThread thread = getThreadByDesignerId(targetThreadDesignerId);
-        thread.progressStep();
+    public void responseEstimateThread(GroomingBiddingThread.ID targetThreadId) {
+        getThreadForChangeState(targetThreadId).responseEstimate();
+    }
+
+    public void reserveThread(GroomingBiddingThread.ID targetThreadId) {
+        getThreadForChangeState(targetThreadId).reserve();
+    }
+
+    public void completeThread(GroomingBiddingThread.ID targetThreadId) {
+        getThreadForChangeState(targetThreadId).complete();
+    }
+
+    public void responseEstimateThread(DesignerId targetThreadDesignerId) {
+        getThreadForChangeState(targetThreadDesignerId).responseEstimate();
+    }
+
+    public void reserveThread(DesignerId targetThreadDesignerId) {
+        getThreadForChangeState(targetThreadDesignerId).reserve();
+    }
+
+    public void completeThread(DesignerId targetThreadDesignerId) {
+        getThreadForChangeState(targetThreadDesignerId).complete();
     }
 
     public void cancelThread(GroomingBiddingThread.ID targetThreadId) {
-        GroomingBiddingThread thread = getThreadByThreadId(targetThreadId);
-        thread.cancel();
+        getThreadForChangeState(targetThreadId).cancel();
     }
 
-    public void cancelThread(DesignerId targetDesignerId) {
-        GroomingBiddingThread thread = getThreadByDesignerId(targetDesignerId);
-        thread.cancel();
+    public void cancelThread(DesignerId targetThreadDesignerId) {
+        getThreadForChangeState(targetThreadDesignerId).cancel();
     }
 
-    public GroomingBiddingThread getThreadByThreadId(GroomingBiddingThread.ID threadId) {
+    public GroomingBiddingThread getThread(GroomingBiddingThread.ID threadThreadId) {
         return threads.stream()
-                .filter(thread -> thread.getId().value().equals(threadId.value()))
+                .filter(thread -> thread.getId().value().equals(threadThreadId.value()))
                 .findFirst()
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_FOUND_BIDDING_THREAD_IN_PROCESS));
     }
 
-    public GroomingBiddingThread getThreadByDesignerId(DesignerId designerId) {
+    public GroomingBiddingThread getThread(DesignerId threadThreadDesignerId) {
         return threads.stream()
-                .filter(thread -> thread.getDesignerId().value().equals(designerId.value()))
+                .filter(thread -> thread.getDesignerId().value().equals(threadThreadDesignerId.value()))
                 .findFirst()
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_FOUND_BIDDING_THREAD_IN_PROCESS));
     }
@@ -121,6 +131,16 @@ public class GroomingBiddingProcess {
 
     public void onThreadCompleted() {
         changeStatus(GroomingBiddingProcessStatus.COMPLETED);
+    }
+
+    private GroomingBiddingThread getThreadForChangeState(DesignerId targetThreadDesignerId) {
+        validateProcessStatus();
+        return getThread(targetThreadDesignerId);
+    }
+
+    private GroomingBiddingThread getThreadForChangeState(GroomingBiddingThread.ID targetThreaId) {
+        validateProcessStatus();
+        return getThread(targetThreaId);
     }
 
     private void validateProcessStatus() {

--- a/peauty-domain/src/main/java/com/peauty/domain/grooming/GroomingBiddingThreadStatus.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/grooming/GroomingBiddingThreadStatus.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 @Getter
 public enum GroomingBiddingThreadStatus {
 
-    ONGOING("진행 중"),
+    NORMAL("정상"),
     CANCELED("취소"),
     WAITING("대기");
 
@@ -23,8 +23,8 @@ public enum GroomingBiddingThreadStatus {
         return this == CANCELED;
     }
 
-    public boolean isOngoing() {
-        return this == ONGOING;
+    public boolean isNormal() {
+        return this == NORMAL;
     }
 
     public boolean isWaiting() {

--- a/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
@@ -49,6 +49,8 @@ public enum PeautyResponseCode {
     CANNOT_CANCEL_COMPLETED_THREAD("1313", "Cannot Cancel Completed Thread", "완료된 입찰 스레드는 취소할 수 없습니다."),
     CANNOT_PROGRESS_CANCELED_THREAD_STEP("1314", "Cannot Progress Canceled Thread Step", "취소된 스레드의 단계는 변경할 수 없습니다."),
     CANNOT_PROGRESS_WAITING_THREAD_STEP("1315", "Cannot Progress Waiting Thread Step", "대기 중인 스레드의 단계는 변경할 수 없습니다."),
+    INVALID_STEP_PROGRESSING("1316", "Invalid Step Progressing", "해당 단계로 올릴 수 있는 단계가 아닙니다."),
+
     // AWS 관련 (7000 ~ 8000)
     IMAGE_UPLOAD_FAIl("7001", "Fail To Upload Image To S3", "S3 에 이미지를 업로드하는 것을 실패했습니다."),
 

--- a/peauty-domain/src/test/java/grooming/GroomingBiddingScenarioTest.java
+++ b/peauty-domain/src/test/java/grooming/GroomingBiddingScenarioTest.java
@@ -1,0 +1,196 @@
+package grooming;
+
+import com.peauty.domain.grooming.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@DisplayName("프로세스 상태 변경 테스트")
+class GroomingBiddingScenarioTest {
+
+    private PuppyId puppyId;
+    private DesignerId designerId;
+    private GroomingBiddingProcess process;
+    private GroomingBiddingThread.ID thread1Id;
+    private GroomingBiddingThread.ID thread2Id;
+    private GroomingBiddingThread.ID thread3Id;
+    private GroomingBiddingThreadTimeInfo threadTimeInfo;
+    private GroomingBiddingProcessTimeInfo processTimeInfo;
+
+    @BeforeEach
+    void setUp() {
+        puppyId = new PuppyId(1L);
+        designerId = new DesignerId(1L);
+        threadTimeInfo = mock(GroomingBiddingThreadTimeInfo.class);
+        processTimeInfo = mock(GroomingBiddingProcessTimeInfo.class);
+        // 세 개의 스레드 준비
+        GroomingBiddingThread thread1 = GroomingBiddingThread.loadThread(
+                new GroomingBiddingThread.ID(1L),
+                puppyId,
+                new DesignerId(1L),
+                GroomingBiddingThreadStep.ESTIMATE_REQUEST,
+                GroomingBiddingThreadStatus.NORMAL,
+                threadTimeInfo
+        );
+
+        GroomingBiddingThread thread2 = GroomingBiddingThread.loadThread(
+                new GroomingBiddingThread.ID(2L),
+                puppyId,
+                new DesignerId(2L),
+                GroomingBiddingThreadStep.ESTIMATE_REQUEST,
+                GroomingBiddingThreadStatus.NORMAL,
+                threadTimeInfo
+        );
+
+        GroomingBiddingThread thread3 = GroomingBiddingThread.loadThread(
+                new GroomingBiddingThread.ID(3L),
+                puppyId,
+                new DesignerId(3L),
+                GroomingBiddingThreadStep.ESTIMATE_REQUEST,
+                GroomingBiddingThreadStatus.NORMAL,
+                threadTimeInfo
+        );
+
+        thread1Id = thread1.getId();
+        thread2Id = thread2.getId();
+        thread3Id = thread3.getId();
+
+        List<GroomingBiddingThread> threads = List.of(thread1, thread2, thread3);
+
+        // 프로세스 생성
+        process = GroomingBiddingProcess.loadProcess(
+                new GroomingBiddingProcess.ID(1L),
+                puppyId,
+                GroomingBiddingProcessStatus.RESERVED_YET,
+                processTimeInfo,
+                threads
+        );
+    }
+
+    @Test
+    @DisplayName("한 스레드가 예약 상태가 되면 다른 스레드들이 대기 상태로 변경된다")
+    void changeOtherThreadsToWaitingWhenOneThreadReserved() {
+        // when
+        process.responseEstimateThread(thread1Id); // ESTIMATE_REQUEST -> ESTIMATE_RESPONSE
+        process.reserveThread(thread1Id);          // ESTIMATE_RESPONSE -> RESERVED
+
+        // then
+        // 첫 번째 스레드는 RESERVED 상태
+        GroomingBiddingThread firstThread = process.getThread(thread1Id);
+        assertEquals(GroomingBiddingThreadStep.RESERVED, firstThread.getStep());
+
+        // 나머지 스레드들은 WAITING 상태로 변경
+        GroomingBiddingThread secondThread = process.getThread(thread2Id);
+        GroomingBiddingThread thirdThread = process.getThread(thread3Id);
+
+        assertEquals(GroomingBiddingThreadStatus.WAITING, secondThread.getStatus());
+        assertEquals(GroomingBiddingThreadStatus.WAITING, thirdThread.getStatus());
+
+        // 프로세스는 RESERVED 상태
+        assertEquals(GroomingBiddingProcessStatus.RESERVED, process.getStatus());
+    }
+
+    @Test
+    @DisplayName("예약된 스레드가 취소되면 다른 스레드들이 진행중 상태로 변경된다")
+    void changeWaitingThreadsToOngoingWhenReservedThreadCanceled() {
+        // given
+        process.responseEstimateThread(thread1Id); // ESTIMATE_REQUEST -> ESTIMATE_RESPONSE
+        process.reserveThread(thread1Id);          // ESTIMATE_RESPONSE -> RESERVED
+
+        // when
+        process.cancelThread(thread1Id);
+
+        // then
+        // 예약됐던 스레드는 취소 상태
+        GroomingBiddingThread firstThread = process.getThread(thread1Id);
+        assertEquals(GroomingBiddingThreadStatus.CANCELED, firstThread.getStatus());
+
+        // 나머지 스레드들은 다시 NORMAL 상태로 변경
+        GroomingBiddingThread secondThread = process.getThread(thread2Id);
+        GroomingBiddingThread thirdThread = process.getThread(thread3Id);
+
+        assertEquals(GroomingBiddingThreadStatus.NORMAL, secondThread.getStatus());
+        assertEquals(GroomingBiddingThreadStatus.NORMAL, thirdThread.getStatus());
+
+        // 프로세스는 RESERVED_YET 상태로 변경
+        assertEquals(GroomingBiddingProcessStatus.RESERVED_YET, process.getStatus());
+    }
+
+    @Test
+    @DisplayName("예약 단계로 진행 시 취소된 스레드를 제외한 나머지 스레드들만 대기 상태로 변경된다")
+    void changeOnlyActiveThreadsToWaitingWhenReserved() {
+        // given
+        process.cancelThread(thread3Id);  // 3번 스레드 취소
+        process.responseEstimateThread(thread1Id);  // 1번 스레드 견적 응답
+
+        // when
+        process.reserveThread(thread1Id);  // 1번 스레드 예약
+
+        // then
+        // 1번 스레드는 예약 상태
+        GroomingBiddingThread thread1 = process.getThread(thread1Id);
+        assertEquals(GroomingBiddingThreadStep.RESERVED, thread1.getStep());
+        assertEquals(GroomingBiddingThreadStatus.NORMAL, thread1.getStatus());
+
+        // 2번 스레드는 대기 상태
+        GroomingBiddingThread thread2 = process.getThread(thread2Id);
+        assertEquals(GroomingBiddingThreadStep.ESTIMATE_REQUEST, thread2.getStep());
+        assertEquals(GroomingBiddingThreadStatus.WAITING, thread2.getStatus());
+
+        // 3번 스레드는 여전히 취소 상태
+        GroomingBiddingThread thread3 = process.getThread(thread3Id);
+        assertEquals(GroomingBiddingThreadStep.ESTIMATE_REQUEST, thread3.getStep());
+        assertEquals(GroomingBiddingThreadStatus.CANCELED, thread3.getStatus());
+
+        // 프로세스는 예약 상태
+        assertEquals(GroomingBiddingProcessStatus.RESERVED, process.getStatus());
+
+        // TimeInfo 검증
+        verify(threadTimeInfo, times(2)).onStepChange();  // 1번 스레드의 견적응답, 예약
+        verify(threadTimeInfo, times(2)).onStatusChange(); // 2번 스레드의 대기, 3번 스레드의 취소
+        verify(processTimeInfo).onStatusChange();  // 프로세스의 예약
+    }
+
+    @Test
+    @DisplayName("예약된 스레드 취소 시 취소된 스레드를 제외한 나머지 스레드들만 진행중 상태로 변경된다")
+    void changeOnlyWaitingThreadsToOngoingWhenReservedThreadCanceled() {
+        // given
+        process.cancelThread(thread3Id);  // 3번 스레드 취소
+        process.responseEstimateThread(thread1Id);  // 1번 스레드 견적 응답
+        process.reserveThread(thread1Id);  // 1번 스레드 예약
+
+        // 이 시점에서 2번만 WAITING 상태
+
+        // when
+        process.cancelThread(thread1Id);  // 예약된 1번 스레드 취소
+
+        // then
+        // 1번 스레드는 취소 상태
+        GroomingBiddingThread thread1 = process.getThread(thread1Id);
+        assertEquals(GroomingBiddingThreadStep.RESERVED, thread1.getStep());
+        assertEquals(GroomingBiddingThreadStatus.CANCELED, thread1.getStatus());
+
+        // 2번 스레드는 다시 진행중 상태
+        GroomingBiddingThread thread2 = process.getThread(thread2Id);
+        assertEquals(GroomingBiddingThreadStep.ESTIMATE_REQUEST, thread2.getStep());
+        assertEquals(GroomingBiddingThreadStatus.NORMAL, thread2.getStatus());
+
+        // 3번 스레드는 여전히 취소 상태
+        GroomingBiddingThread thread3 = process.getThread(thread3Id);
+        assertEquals(GroomingBiddingThreadStep.ESTIMATE_REQUEST, thread3.getStep());
+        assertEquals(GroomingBiddingThreadStatus.CANCELED, thread3.getStatus());
+
+        // 프로세스는 예약 전 상태
+        assertEquals(GroomingBiddingProcessStatus.RESERVED_YET, process.getStatus());
+
+        // TimeInfo 검증
+        verify(threadTimeInfo, times(2)).onStepChange();  // 1번 스레드의 견적응답, 예약
+        verify(threadTimeInfo, times(4)).onStatusChange(); // 2번의 대기->진행중, 1번과 3번의 취소
+        verify(processTimeInfo, times(2)).onStatusChange();  // 프로세스의 예약->예약전
+    }
+}


### PR DESCRIPTION
## 📄 [PEAUTY-92] Divide progress step into 3 way

Jira : [PEAUTY-92](https://multicampusuplus.atlassian.net/browse/PEAUTY-92?atlOrigin=eyJpIjoiZjMyNDMzZThhNDcxNDRkMjhlYzBiODdiMGUwNTBjNzciLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명

- 스레드의 스텝을 올리는 주체가 고객, 미용사 둘이고 주체에 따라 스텝을 올리는 세부 로직이 달라질 수 있기 떄문에 기존 progressStep 메소드를 responseEstimate, reserve, complete 세 가지로 나눴습니다.
- step 이 COMPLETED(완료) 인 스레드의 상태가 ONGOING(진행 중) 인 것이 어색하기 때문에 기존의 ONGOING(진행 중) 을 NORMAL(정상) 으로 바꿨습니다
- 복잡한 비즈니스 로직의 검증을 위해 ScenarioTest 를 추가했습니다

<!-- Pull Request의 설명을 추가하세요. -->

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.3 MD
- Actual MD: 0.3 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
