### PR TITLE
[PEAUTY-95] Create Searching Around Workspace

### DIFF
--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerPort.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerPort.java
@@ -2,10 +2,7 @@ package com.peauty.customer.business.customer;
 
 import com.peauty.customer.business.auth.dto.SignUpCommand;
 import com.peauty.domain.customer.Customer;
-import com.peauty.domain.designer.Designer;
-import com.peauty.domain.designer.Workspace;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface CustomerPort {
@@ -18,7 +15,6 @@ public interface CustomerPort {
     Customer getByCustomerIdWithoutPuppies(Long customerId);
     Customer getCustomerById(Long customerId);
 
-    List<Workspace> findAllWorkspaceByAddress(String address);
-    Designer findDesignerById(Long designerId);
+
 
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerPort.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerPort.java
@@ -2,7 +2,10 @@ package com.peauty.customer.business.customer;
 
 import com.peauty.customer.business.auth.dto.SignUpCommand;
 import com.peauty.domain.customer.Customer;
+import com.peauty.domain.designer.Designer;
+import com.peauty.domain.designer.Workspace;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CustomerPort {
@@ -14,4 +17,8 @@ public interface CustomerPort {
     Customer registerNewCustomer(SignUpCommand command);
     Customer getByCustomerIdWithoutPuppies(Long customerId);
     Customer getCustomerById(Long customerId);
+
+    List<Workspace> findAllWorkspaceByAddress(String address);
+    Designer findDesignerById(Long designerId);
+
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerService.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerService.java
@@ -8,4 +8,5 @@ public interface CustomerService {
     GetCustomerProfileResult getCustomerProfile(Long customerId);
     UpdateCustomerProfileResult updateCustomerProfile(Long customerId, UpdateCustomerProfileCommand command);
     void checkCustomerNicknameDuplicated(String nickname);
+    GetAroundWorkspacesResult getAroundWorkspaces(Long customerId);
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
@@ -3,10 +3,16 @@ package com.peauty.customer.business.customer;
 import com.peauty.customer.business.customer.dto.*;
 import com.peauty.customer.business.internal.InternalPort;
 import com.peauty.domain.customer.Customer;
+import com.peauty.domain.designer.Designer;
+import com.peauty.domain.designer.Workspace;
+import com.peauty.domain.exception.PeautyException;
+import com.peauty.domain.response.PeautyResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -48,6 +54,81 @@ public class CustomerServiceImpl implements CustomerService {
     public void checkCustomerNicknameDuplicated(String nickname) {
         customerPort.checkCustomerNicknameDuplicated(nickname);
     }
+
+/*    @Override
+    public GetAroundDesignersResult getAroundDesigners(Long customerId) {
+        // 고객 정보 가져오기
+        Customer customer = customerPort.getCustomerById(customerId);
+        // 고객 주소와 같은 디자이너 조회
+        List<Designer> designers = customerPort.findDesignersByAddress(customer.getAddress());
+        // 디자이너들의 작업공간 정보 가져오기
+        List<Workspace> workspaces = designers.stream()
+                .map(designer -> customerPort.getWorkspaceByDesignerId(designer.getDesignerId()))
+                .toList();
+
+        return GetAroundDesignersResult.from(customer, designers, workspaces);
+    }*/
+
+/*  TEST
+    @Override
+    public GetAroundWorkspacesResult getAroundWorkspaces(Long customerId) {
+        // 고객 정보 조회와 상위 주소를 추출
+        Customer customer = customerPort.getCustomerById(customerId);
+        String customerBaseAddress = extractBaseAddress(customer.getAddress());
+        // 고객의 상위 주소와 일치하는 미용실을 조회
+        List<Workspace> workspaces = customerPort.findAllWorkspaceByAddress(customerBaseAddress);
+        // 일치하는 미용실과 디자이너의 정보를 매핑
+        List<GetAroundWorkspacesResult.WorkspaceWithDesigner> workspaceWithDesigners = workspaces.stream()
+                .map(workspace -> {
+                    Designer designer = customerPort.findDesignerById(workspace.getDesignerId());
+                    return new GetAroundWorkspacesResult.WorkspaceWithDesigner(
+                            workspace.getWorkspaceId(),
+                            workspace.getWorkspaceName(),
+                            workspace.getAddress(),
+                            workspace.getAddressDetail(),
+                            workspace.getBannerImageUrl(),
+                            workspace.getReviewCount(),
+                            workspace.getReviewRating(),
+                            designer.getName(),
+                            designer.getYearOfExperience()
+                    );
+                })
+                .toList();
+
+        return new GetAroundWorkspacesResult(customer.getCustomerId(), customer.getAddress(), workspaceWithDesigners);
+    }*/
+    @Override
+    public GetAroundWorkspacesResult getAroundWorkspaces(Long customerId) {
+        // 고객 정보 조회
+        Customer customer = customerPort.getCustomerById(customerId);
+        // OO시 OO구 까지 추출
+        String customerBaseAddress = extractBaseAddress(customer.getAddress());
+        // 고객의 상위주소와 맞는 미용실 전체 조회
+        List<Workspace> workspaces = customerPort.findAllWorkspaceByAddress(customerBaseAddress);
+        // 각 미용실에 해당하는 디자이너 정보를 매핑
+        List<GetAroundWorkspaceResult> workspaceResults = workspaces.stream()
+                .map(workspace -> {
+                    // 미용실을 소유한 디자이너 조회
+                    Designer designer = customerPort.findDesignerById(workspace.getDesignerId());
+                    return GetAroundWorkspaceResult.from(workspace, designer);
+                })
+                .toList();
+
+        return GetAroundWorkspacesResult.from(customer, workspaceResults);
+    }
+
+    private String extractBaseAddress(String address) {
+        // 어절(띄어쓰기)로 파싱.
+        // 서울 강남구 대치동 -> 서울 강남구
+        String[] addressParts = address.split(" ");
+        if (addressParts.length < 2) {
+        // "" or "서울시"
+            throw new PeautyException(PeautyResponseCode.INVALID_ADDRESS_FORMAT);
+        }
+        // 상위 주소만 딱 반환해버리기
+        return addressParts[0] + " " + addressParts[1];
+    }
+
 
 
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
@@ -2,6 +2,7 @@ package com.peauty.customer.business.customer;
 
 import com.peauty.customer.business.customer.dto.*;
 import com.peauty.customer.business.internal.InternalPort;
+import com.peauty.customer.business.workspace.WorkspacePort;
 import com.peauty.domain.customer.Customer;
 import com.peauty.domain.designer.Designer;
 import com.peauty.domain.designer.Workspace;
@@ -21,6 +22,7 @@ public class CustomerServiceImpl implements CustomerService {
 
     private final CustomerPort customerPort;
     private final InternalPort internalPort;
+    private final WorkspacePort workspacePort;
 
     @Override
     @Transactional
@@ -55,48 +57,6 @@ public class CustomerServiceImpl implements CustomerService {
         customerPort.checkCustomerNicknameDuplicated(nickname);
     }
 
-/*    @Override
-    public GetAroundDesignersResult getAroundDesigners(Long customerId) {
-        // 고객 정보 가져오기
-        Customer customer = customerPort.getCustomerById(customerId);
-        // 고객 주소와 같은 디자이너 조회
-        List<Designer> designers = customerPort.findDesignersByAddress(customer.getAddress());
-        // 디자이너들의 작업공간 정보 가져오기
-        List<Workspace> workspaces = designers.stream()
-                .map(designer -> customerPort.getWorkspaceByDesignerId(designer.getDesignerId()))
-                .toList();
-
-        return GetAroundDesignersResult.from(customer, designers, workspaces);
-    }*/
-
-/*  TEST
-    @Override
-    public GetAroundWorkspacesResult getAroundWorkspaces(Long customerId) {
-        // 고객 정보 조회와 상위 주소를 추출
-        Customer customer = customerPort.getCustomerById(customerId);
-        String customerBaseAddress = extractBaseAddress(customer.getAddress());
-        // 고객의 상위 주소와 일치하는 미용실을 조회
-        List<Workspace> workspaces = customerPort.findAllWorkspaceByAddress(customerBaseAddress);
-        // 일치하는 미용실과 디자이너의 정보를 매핑
-        List<GetAroundWorkspacesResult.WorkspaceWithDesigner> workspaceWithDesigners = workspaces.stream()
-                .map(workspace -> {
-                    Designer designer = customerPort.findDesignerById(workspace.getDesignerId());
-                    return new GetAroundWorkspacesResult.WorkspaceWithDesigner(
-                            workspace.getWorkspaceId(),
-                            workspace.getWorkspaceName(),
-                            workspace.getAddress(),
-                            workspace.getAddressDetail(),
-                            workspace.getBannerImageUrl(),
-                            workspace.getReviewCount(),
-                            workspace.getReviewRating(),
-                            designer.getName(),
-                            designer.getYearOfExperience()
-                    );
-                })
-                .toList();
-
-        return new GetAroundWorkspacesResult(customer.getCustomerId(), customer.getAddress(), workspaceWithDesigners);
-    }*/
     @Override
     public GetAroundWorkspacesResult getAroundWorkspaces(Long customerId) {
         // 고객 정보 조회
@@ -104,12 +64,12 @@ public class CustomerServiceImpl implements CustomerService {
         // OO시 OO구 까지 추출
         String customerBaseAddress = extractBaseAddress(customer.getAddress());
         // 고객의 상위주소와 맞는 미용실 전체 조회
-        List<Workspace> workspaces = customerPort.findAllWorkspaceByAddress(customerBaseAddress);
+        List<Workspace> workspaces = workspacePort.findAllWorkspaceByAddress(customerBaseAddress);
         // 각 미용실에 해당하는 디자이너 정보를 매핑
         List<GetAroundWorkspaceResult> workspaceResults = workspaces.stream()
                 .map(workspace -> {
                     // 미용실을 소유한 디자이너 조회
-                    Designer designer = customerPort.findDesignerById(workspace.getDesignerId());
+                    Designer designer = workspacePort.findDesignerById(workspace.getDesignerId());
                     return GetAroundWorkspaceResult.from(workspace, designer);
                 })
                 .toList();

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/dto/GetAroundWorkspaceResult.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/dto/GetAroundWorkspaceResult.java
@@ -1,0 +1,30 @@
+package com.peauty.customer.business.customer.dto;
+
+import com.peauty.domain.designer.Designer;
+import com.peauty.domain.designer.Workspace;
+
+public record GetAroundWorkspaceResult(
+        Long workspaceId,
+        String workspaceName,
+        String address,
+        String addressDetail,
+        String bannerImageUrl,
+        Integer reviewCount,
+        Double reviewRating,
+        String designerName,
+        Integer yearOfExperience
+) {
+    public static GetAroundWorkspaceResult from(Workspace workspace, Designer designer) {
+        return new GetAroundWorkspaceResult(
+                workspace.getWorkspaceId(),
+                workspace.getWorkspaceName(),
+                workspace.getAddress(),
+                workspace.getAddressDetail(),
+                workspace.getBannerImageUrl(),
+                workspace.getReviewCount(),
+                workspace.getReviewRating(),
+                designer.getName(),
+                designer.getYearOfExperience()
+        );
+    }
+}

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/dto/GetAroundWorkspacesResult.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/dto/GetAroundWorkspacesResult.java
@@ -1,0 +1,19 @@
+package com.peauty.customer.business.customer.dto;
+
+import com.peauty.domain.customer.Customer;
+
+import java.util.List;
+
+public record GetAroundWorkspacesResult(
+        Long customerId,
+        String customerAddress,
+        List<GetAroundWorkspaceResult> workspaces
+) {
+    public static GetAroundWorkspacesResult from(Customer customer, List<GetAroundWorkspaceResult> workspaceResults) {
+        return new GetAroundWorkspacesResult(
+                customer.getCustomerId(),
+                customer.getAddress(),
+                workspaceResults
+        );
+    }
+}

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspacePort.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspacePort.java
@@ -1,0 +1,13 @@
+package com.peauty.customer.business.workspace;
+
+import com.peauty.domain.designer.Designer;
+import com.peauty.domain.designer.Workspace;
+
+import java.util.List;
+
+public interface WorkspacePort {
+
+    List<Workspace> findAllWorkspaceByAddress(String address);
+    Designer findDesignerById(Long designerId);
+
+}

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/customer/CustomerAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/customer/CustomerAdapter.java
@@ -3,15 +3,20 @@ package com.peauty.customer.implementaion.customer;
 import com.peauty.customer.business.auth.dto.SignUpCommand;
 import com.peauty.customer.business.customer.CustomerPort;
 import com.peauty.domain.customer.Customer;
+import com.peauty.domain.designer.Designer;
+import com.peauty.domain.designer.Workspace;
 import com.peauty.domain.exception.PeautyException;
 import com.peauty.domain.response.PeautyResponseCode;
 import com.peauty.domain.user.Role;
 import com.peauty.domain.user.Status;
 import com.peauty.persistence.customer.CustomerEntity;
 import com.peauty.persistence.customer.CustomerRepository;
+import com.peauty.persistence.designer.DesignerRepository;
+import com.peauty.persistence.designer.WorkspaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -19,6 +24,8 @@ import java.util.Optional;
 public class CustomerAdapter implements CustomerPort {
 
     private final CustomerRepository customerRepository;
+    private final DesignerRepository designerRepository;
+    private final WorkspaceRepository workspaceRepository;
 
     @Override
     public void checkCustomerSocialIdDuplicated(String socialId) {
@@ -84,6 +91,21 @@ public class CustomerAdapter implements CustomerPort {
         return customerRepository.findById(customerId)
                 .map(CustomerMapper::toDomain)
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_USER));
+    }
+
+    @Override
+    public List<Workspace> findAllWorkspaceByAddress(String baseAddress) {
+        return workspaceRepository.findByBaseAddress(baseAddress)
+                .stream()
+                .map(CustomerMapper::toWorkspaceDomain)
+                .toList();
+    }
+
+    @Override
+    public Designer findDesignerById(Long designerId) {
+        return designerRepository.findById(designerId)
+                .map(CustomerMapper::toDesignerDomain)
+                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_DESIGNER));
     }
 
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/customer/CustomerAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/customer/CustomerAdapter.java
@@ -3,8 +3,6 @@ package com.peauty.customer.implementaion.customer;
 import com.peauty.customer.business.auth.dto.SignUpCommand;
 import com.peauty.customer.business.customer.CustomerPort;
 import com.peauty.domain.customer.Customer;
-import com.peauty.domain.designer.Designer;
-import com.peauty.domain.designer.Workspace;
 import com.peauty.domain.exception.PeautyException;
 import com.peauty.domain.response.PeautyResponseCode;
 import com.peauty.domain.user.Role;
@@ -16,7 +14,6 @@ import com.peauty.persistence.designer.WorkspaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -24,8 +21,6 @@ import java.util.Optional;
 public class CustomerAdapter implements CustomerPort {
 
     private final CustomerRepository customerRepository;
-    private final DesignerRepository designerRepository;
-    private final WorkspaceRepository workspaceRepository;
 
     @Override
     public void checkCustomerSocialIdDuplicated(String socialId) {
@@ -91,21 +86,6 @@ public class CustomerAdapter implements CustomerPort {
         return customerRepository.findById(customerId)
                 .map(CustomerMapper::toDomain)
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_USER));
-    }
-
-    @Override
-    public List<Workspace> findAllWorkspaceByAddress(String baseAddress) {
-        return workspaceRepository.findByBaseAddress(baseAddress)
-                .stream()
-                .map(CustomerMapper::toWorkspaceDomain)
-                .toList();
-    }
-
-    @Override
-    public Designer findDesignerById(Long designerId) {
-        return designerRepository.findById(designerId)
-                .map(CustomerMapper::toDesignerDomain)
-                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_DESIGNER));
     }
 
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/customer/CustomerMapper.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/customer/CustomerMapper.java
@@ -1,8 +1,19 @@
 package com.peauty.customer.implementaion.customer;
 
 import com.peauty.domain.customer.Customer;
+import com.peauty.domain.designer.*;
 import com.peauty.domain.user.Role;
 import com.peauty.persistence.customer.CustomerEntity;
+import com.peauty.persistence.designer.DesignerEntity;
+import com.peauty.persistence.designer.LicenseEntity;
+import com.peauty.persistence.designer.RatingEntity;
+import com.peauty.persistence.designer.WorkspaceEntity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class CustomerMapper {
 
@@ -38,4 +49,71 @@ public class CustomerMapper {
                 .profileImageUrl(customer.getProfileImageUrl())
                 .build();
     }
+    // 엔티티 -> 도메인
+    public static Designer toDesignerDomain(DesignerEntity entity) {
+        return Designer.builder()
+                .designerId(entity.getId())
+                .name(entity.getName())
+                .nickname(entity.getNickname())
+                .profileImageUrl(entity.getProfileImageUrl())
+                .yearOfExperience(entity.getYearsOfExperience())
+                .build();
+    }
+    // 엔티티 -> 도메인
+    public static Workspace toWorkspaceDomain(WorkspaceEntity entity) {
+        return Workspace.builder()
+                .workspaceId(entity.getId())
+                .designerId(entity.getDesignerId())
+                .workspaceName(entity.getWorkspaceName())
+                .address(entity.getAddress())
+                .addressDetail(entity.getAddressDetail())
+                .bannerImageUrl(entity.getBannerImageUrl())
+                .reviewCount(entity.getReviewCount())
+                .reviewRating(entity.getReviewRating())
+                .build();
+    }
+
+    public static List<License> toLicenses(List<LicenseEntity> licenseEntities) {
+        return Optional.ofNullable(licenseEntities)
+                .orElse(Collections.emptyList()) // Null일 경우 빈 리스트 반환
+                .stream()
+                .filter(Objects::nonNull) // 리스트 내부 요소도 null 체크
+                .map(licenseEntity -> License.builder()
+                        .licenseId(licenseEntity.getId())
+                        .licenseImageUrl(licenseEntity.getLicenseImageUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    public static List<LicenseEntity> toLicenseEntity(Designer designer) {
+        List<License> licenses = designer.getLicenses();
+        if (licenses == null || licenses.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return licenses.stream()
+                .map(license -> LicenseEntity.builder()
+                        .licenseImageUrl(license.getLicenseImageUrl()) // License 이미지 URL 설정
+                        .designerId(designer.getDesignerId()) // Designer의 ID 설정
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+
+    public static Rating toRatingDomain(RatingEntity rating) {
+        if (rating == null) {
+            return Rating.builder()
+                    .ratingId(0L)
+                    .totalScore(0.0)
+                    .scissor(Scissor.NONE)
+                    .build();
+        }
+
+        return Rating.builder()
+                .ratingId(rating.getId())
+                .totalScore(rating.getTotalScore())
+                .scissor(rating.getScissor())
+                .build();
+    }
+
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/workspace/WorkspaceAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/workspace/WorkspaceAdapter.java
@@ -1,0 +1,38 @@
+package com.peauty.customer.implementaion.workspace;
+
+import com.peauty.customer.business.workspace.WorkspacePort;
+import com.peauty.customer.implementaion.customer.CustomerMapper;
+import com.peauty.domain.designer.Designer;
+import com.peauty.domain.designer.Workspace;
+import com.peauty.domain.exception.PeautyException;
+import com.peauty.domain.response.PeautyResponseCode;
+import com.peauty.persistence.designer.DesignerRepository;
+import com.peauty.persistence.designer.WorkspaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WorkspaceAdapter implements WorkspacePort {
+
+    private final DesignerRepository designerRepository;
+    private final WorkspaceRepository workspaceRepository;
+
+    @Override
+    public List<Workspace> findAllWorkspaceByAddress(String baseAddress) {
+        return workspaceRepository.findByBaseAddress(baseAddress)
+                .stream()
+                .map(CustomerMapper::toWorkspaceDomain)
+                .toList();
+    }
+
+    @Override
+    public Designer findDesignerById(Long designerId) {
+        return designerRepository.findById(designerId)
+                .map(CustomerMapper::toDesignerDomain)
+                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_DESIGNER));
+    }
+
+}

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/CustomerController.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/CustomerController.java
@@ -2,6 +2,7 @@ package com.peauty.customer.presentation.controller.customer;
 
 import com.peauty.customer.business.customer.CustomerService;
 import com.peauty.customer.business.customer.dto.*;
+import com.peauty.customer.presentation.controller.customer.dto.GetAroundWorkspacesResponse;
 import com.peauty.customer.presentation.controller.customer.dto.GetCustomerProfileResponse;
 import com.peauty.customer.presentation.controller.customer.dto.UploadProfileImageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -49,4 +50,12 @@ public class CustomerController {
         customerService.checkCustomerNicknameDuplicated(nickname);
         return new CheckCustomerNicknameDuplicatedResponse("사용해도 좋은 닉네임입니다.");
     }
+
+    @GetMapping("/{userId}/serach")
+    @Operation(summary = "주변 디자이너 매장 조회", description = "고객 주소와 같은 디자이너의 매장을 조회하는 API 진입점입니다.")
+    public GetAroundWorkspacesResponse getAroundWorkspaces(@PathVariable Long userId) {
+        GetAroundWorkspacesResult result = customerService.getAroundWorkspaces(userId);
+        return GetAroundWorkspacesResponse.from(result);
+    }
+
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetAroundWorkspaceResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetAroundWorkspaceResponse.java
@@ -1,0 +1,29 @@
+package com.peauty.customer.presentation.controller.customer.dto;
+
+import com.peauty.customer.business.customer.dto.GetAroundWorkspaceResult;
+
+public record GetAroundWorkspaceResponse(
+        Long workspaceId,
+        String workspaceName,
+        String address,
+        String addressDetail,
+        String bannerImageUrl,
+        Integer reviewCount,
+        Double reviewRating,
+        String designerName,
+        Integer yearOfExperience
+) {
+    public static GetAroundWorkspaceResponse from(GetAroundWorkspaceResult result) {
+        return new GetAroundWorkspaceResponse(
+                result.workspaceId(),
+                result.workspaceName(),
+                result.address(),
+                result.addressDetail(),
+                result.bannerImageUrl(),
+                result.reviewCount(),
+                result.reviewRating(),
+                result.designerName(),
+                result.yearOfExperience()
+        );
+    }
+}

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetAroundWorkspacesResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetAroundWorkspacesResponse.java
@@ -1,0 +1,23 @@
+package com.peauty.customer.presentation.controller.customer.dto;
+
+import com.peauty.customer.business.customer.dto.GetAroundWorkspacesResult;
+
+import java.util.List;
+
+public record GetAroundWorkspacesResponse(
+        Long customerId,
+        String customerAddress,
+        List<GetAroundWorkspaceResponse> workspaces
+) {
+    public static GetAroundWorkspacesResponse from(GetAroundWorkspacesResult result) {
+        List<GetAroundWorkspaceResponse> workspaceResponses = result.workspaces().stream()
+                .map(GetAroundWorkspaceResponse::from)
+                .toList();
+
+        return new GetAroundWorkspacesResponse(
+                result.customerId(),
+                result.customerAddress(),
+                workspaceResponses
+        );
+    }
+}

--- a/peauty-domain/src/main/java/com/peauty/domain/designer/Workspace.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/designer/Workspace.java
@@ -29,6 +29,8 @@ public class Workspace {
     private String address;
     private String addressDetail;
 
+    private Long designerId;
+
     public void updateRating(Rating rating) {
         this.rating = rating;
     }

--- a/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
@@ -62,6 +62,9 @@ public enum PeautyResponseCode {
     NOT_INITIALIZED_PROCESS("1320", "Not Initialized Process", "초기화되지 않은 프로세스입니다."),
     NOT_FOUND_BIDDING_PROCESS("1321", "Not Found Bidding Process", "해당 입찰 프로세스를 찾을 수 없습니다."),
 
+    INVALID_GROOMING_TYPE("1400", "Invalid Grooming Type", "올바르지 않은 미용 타입입니다."),
+
+
     // AWS 관련 (7000 ~ 8000)
     IMAGE_UPLOAD_FAIl("7001", "Fail To Upload Image To S3", "S3 에 이미지를 업로드하는 것을 실패했습니다."),
 

--- a/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
@@ -32,7 +32,10 @@ public enum PeautyResponseCode {
     NOT_FOUND_WORKSPACE("1211", "Workspace Not Found", "가게가 존재하지 않습니다."),
     INVALID_RATING("1211", "Invalid Rating", "잘못된 리뷰 평점입니다."),
     INVALID_GENERAL_CONTENT("1212", "Invalid GENERAL CONTENT", "잘못된 리뷰 선택 컨텐츠입니다."),
-    INVALID_PAYMENT_OPTION("1213", "Invalid Payment Options", "잘못된 결제 방식입니다"),
+    INVALID_PAYMENT_OPTION("1213", "Invalid Payment Options", "잘못된 결제 방식입니다."),
+
+    INVALID_ADDRESS_FORMAT("1215", "Invalid Address Format", "잘못된 주소 형식입니다."),
+    NOT_EXIST_DESIGNER("1216", "Designer Not Found", "찾을 수 없는 디자이너입니다."),
 
     // 비딩 관련 (1300 ~ 1350)
     WRONG_BIDDING_PROCESS_STEP_DESCRIPTION("1300", "Wrong Bidding Process Step Description", "잘못된 입찰 프로세스입니다."),

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/WorkspaceRepository.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/WorkspaceRepository.java
@@ -1,10 +1,21 @@
 package com.peauty.persistence.designer;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface
 WorkspaceRepository extends JpaRepository<WorkspaceEntity, Long> {
     WorkspaceEntity findByDesignerId(Long userId);
+    Optional<WorkspaceEntity> findAllByDesignerId(Long designerId);
+    List<WorkspaceEntity> findByAddress(String address);
+
+    @Query("SELECT w FROM WorkspaceEntity w WHERE w.address LIKE CONCAT(:baseAddress, '%')")
+    List<WorkspaceEntity> findByBaseAddress(@Param("baseAddress") String baseAddress);
+
 }


### PR DESCRIPTION
[PEAUTY-95] Create Searching Around Workspace

Jira : [PEAUTY-95](https://multicampusuplus.atlassian.net/browse/PEAUTY-95?atlOrigin=eyJpIjoiYzBmMWYzZGMzM2EwNDQwY2JjOGZhYWE2NGMwN2IyOWEiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명
- [x] 버그 수정 설명
- [x] 문서 수정 설명

<!-- Pull Request의 설명을 추가하세요. -->
고객은 본인의 지역 주변에 있는 미용실을 조회할 수 있습니다.
기존에는 미용사의 주소와 일치하는지 확인하는 작업을 거치고 해당 주소를 가진 미용실을 조회했습니다.
현재, 미용사의 주소를 입력하는 과정이 사라지고, 미용실의 주소를 입력하는 과정이 생겼기 때문에 그에 따른 API로 생성했습니다.
ex) 고객 : "서울시 강남구 논현동 11-2"일 때, 어절 단위로 체크해 "서울시 강남구"로 파싱합니다. 파싱한 것을 미용실의 주소와 일치하는지 확인하고, 일치한다면 해당 주소를 가지는 미용실들을 일괄적으로 조회하며, 해당 미용실을 소유한 디자이너와 정보를 매칭합니다.


## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 1 MD
- Actual MD: 1 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
