### PR TITLE
[PEAUTY-124] JPA mapping between processes and threads

### DIFF
--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/BiddingProcessPort.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/BiddingProcessPort.java
@@ -6,5 +6,4 @@ public interface BiddingProcessPort {
 
     BiddingProcess getProcessById(Long processId);
     BiddingProcess save(BiddingProcess process);
-    BiddingProcess initProcess(BiddingProcess process);
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/CustomerBiddingServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/CustomerBiddingServiceImpl.java
@@ -24,12 +24,11 @@ public class CustomerBiddingServiceImpl implements CustomerBiddingService {
             Long puppyId,
             SendEstimateProposalCommand command
     ) {
-        BiddingProcess process = biddingProcessPort.initProcess(BiddingProcess.createNewProcess(new PuppyId(puppyId)));
-        EstimateProposal proposal = command.toEstimateProposal(process.getSavedProcessId());
-        estimateProposalPort.save(proposal);
-        command.designerIds()
-                .forEach(id -> process.addNewThread(new DesignerId(id)));
-        BiddingProcess savedProcess = biddingProcessPort.save(process);
+        BiddingProcess newProcess = BiddingProcess.createNewProcess(new PuppyId(puppyId));
+        command.designerIds().forEach(id -> newProcess.addNewThread(new DesignerId(id)));
+        BiddingProcess savedProcess = biddingProcessPort.save(newProcess);
+        EstimateProposal newProposal = command.toEstimateProposal(savedProcess.getSavedProcessId());
+        estimateProposalPort.save(newProposal);;
         return SendEstimateProposalResult.from(savedProcess);
     }
 

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/bidding/BiddingMapper.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/bidding/BiddingMapper.java
@@ -8,18 +8,18 @@ import java.util.List;
 
 public class BiddingMapper {
 
-    public static BiddingProcess toProcessDomain(BiddingProcessEntity entity) {
-        List<BiddingThread> threads = entity.getThreads().stream()
+    public static BiddingProcess toProcessDomain(BiddingProcessEntity processEntity, List<BiddingThreadEntity> threadEntities) {
+        List<BiddingThread> threads = threadEntities.stream()
                 .map(BiddingMapper::toThreadDomain)
                 .toList();
 
         return BiddingProcess.loadProcess(
-                new BiddingProcess.ID(entity.getId()),
-                new PuppyId(entity.getPuppyId()),
-                entity.getStatus(),
+                new BiddingProcess.ID(processEntity.getId()),
+                new PuppyId(processEntity.getPuppyId()),
+                processEntity.getStatus(),
                 new BiddingProcessTimeInfo(
-                        entity.getCreatedAt(),
-                        entity.getStatusModifiedAt()
+                        processEntity.getCreatedAt(),
+                        processEntity.getStatusModifiedAt()
                 ),
                 threads
         );

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/bidding/BiddingMapper.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/bidding/BiddingMapper.java
@@ -8,64 +8,58 @@ import java.util.List;
 
 public class BiddingMapper {
 
-    public static BiddingProcess toProcessDomain(
-            BiddingProcessEntity processEntity,
-            List<BiddingThreadEntity> threadEntities
-    ) {
-        List<BiddingThread> threads = threadEntities.stream()
+    public static BiddingProcess toProcessDomain(BiddingProcessEntity entity) {
+        List<BiddingThread> threads = entity.getThreads().stream()
                 .map(BiddingMapper::toThreadDomain)
                 .toList();
 
         return BiddingProcess.loadProcess(
-                new BiddingProcess.ID(processEntity.getId()),
-                new PuppyId(processEntity.getPuppyId()),
-                processEntity.getStatus(),
-                new BiddingProcessTimeInfo(processEntity.getCreatedAt(), processEntity.getStatusModifiedAt()),
+                new BiddingProcess.ID(entity.getId()),
+                new PuppyId(entity.getPuppyId()),
+                entity.getStatus(),
+                new BiddingProcessTimeInfo(
+                        entity.getCreatedAt(),
+                        entity.getStatusModifiedAt()
+                ),
                 threads
         );
     }
 
-    public static BiddingProcessEntity toProcessEntity(BiddingProcess process) {
+    public static BiddingProcessEntity toProcessEntity(BiddingProcess domain) {
         return BiddingProcessEntity.builder()
-                .id(process.getId().map(BiddingProcess.ID::value).orElse(null))
-                .puppyId(process.getPuppyId().value())
-                .status(process.getStatus())
-                .createdAt(process.getTimeInfo().getCreatedAt())
-                .statusModifiedAt(process.getTimeInfo().getStatusModifiedAt())
+                .id(domain.getId().map(BiddingProcess.ID::value).orElse(null))
+                .puppyId(domain.getPuppyId().value())
+                .status(domain.getStatus())
+                .createdAt(domain.getTimeInfo().getCreatedAt())
+                .statusModifiedAt(domain.getTimeInfo().getStatusModifiedAt())
                 .build();
     }
 
-    public static BiddingThread toThreadDomain(BiddingThreadEntity threadEntity) {
+    public static BiddingThread toThreadDomain(BiddingThreadEntity entity) {
         return BiddingThread.loadThread(
-                new BiddingThread.ID(threadEntity.getId()),
-                new BiddingProcess.ID(threadEntity.getBiddingProcessId()),
-                new DesignerId(threadEntity.getDesignerId()),
-                threadEntity.getStep(),
-                threadEntity.getStatus(),
+                new BiddingThread.ID(entity.getId()),
+                new BiddingProcess.ID(entity.getBiddingProcess().getId()),
+                new DesignerId(entity.getDesignerId()),
+                entity.getStep(),
+                entity.getStatus(),
                 new BiddingThreadTimeInfo(
-                        threadEntity.getCreatedAt(),
-                        threadEntity.getStepModifiedAt(),
-                        threadEntity.getStatusModifiedAt()
+                        entity.getCreatedAt(),
+                        entity.getStepModifiedAt(),
+                        entity.getStatusModifiedAt()
                 )
         );
     }
 
-    public static BiddingThreadEntity toThreadEntity(BiddingThread thread) {
+    public static BiddingThreadEntity toThreadEntity(BiddingThread domain, BiddingProcessEntity processEntity) {
         return BiddingThreadEntity.builder()
-                .id(thread.getId().map(BiddingThread.ID::value).orElse(null))
-                .biddingProcessId(thread.getProcessId().value())
-                .designerId(thread.getDesignerId().value())
-                .step(thread.getStep())
-                .status(thread.getStatus())
-                .createdAt(thread.getTimeInfo().getCreatedAt())
-                .stepModifiedAt(thread.getTimeInfo().getStepModifiedAt())
-                .statusModifiedAt(thread.getTimeInfo().getStatusModifiedAt())
+                .id(domain.getId().map(BiddingThread.ID::value).orElse(null))
+                .biddingProcess(processEntity)
+                .designerId(domain.getDesignerId().value())
+                .step(domain.getStep())
+                .status(domain.getStatus())
+                .createdAt(domain.getTimeInfo().getCreatedAt())
+                .stepModifiedAt(domain.getTimeInfo().getStepModifiedAt())
+                .statusModifiedAt(domain.getTimeInfo().getStatusModifiedAt())
                 .build();
-    }
-
-    public static List<BiddingThreadEntity> toThreadEntities(List<BiddingThread> threads) {
-        return threads.stream()
-                .map(BiddingMapper::toThreadEntity)
-                .toList();
     }
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/bidding/BiddingProcessAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/bidding/BiddingProcessAdapter.java
@@ -30,22 +30,18 @@ public class BiddingProcessAdapter implements BiddingProcessPort {
         BiddingProcessEntity savedProcessEntity = processRepository.save(
                 BiddingMapper.toProcessEntity(process)
         );
-
         List<BiddingThreadEntity> threadEntities = process.getThreads().stream()
                 .map(thread -> BiddingMapper.toThreadEntity(thread, savedProcessEntity))
                 .toList();
-
         List<BiddingThreadEntity> savedThreads = threadRepository.saveAll(threadEntities);
-        savedProcessEntity.setThreads(savedThreads);
-
-        return BiddingMapper.toProcessDomain(savedProcessEntity);
+        return BiddingMapper.toProcessDomain(savedProcessEntity, savedThreads);
     }
 
     @Override
     public BiddingProcess getProcessById(Long processId) {
-        BiddingProcessEntity foundProcessEntity = processRepository.findByIdWithThread(processId)
+        BiddingProcessEntity foundProcessEntity = processRepository.findById(processId)
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_FOUND_BIDDING_PROCESS));
-
-        return BiddingMapper.toProcessDomain(foundProcessEntity);
+         List<BiddingThreadEntity> foundThreadEntities = threadRepository.findByBiddingProcessId(foundProcessEntity.getId());
+        return BiddingMapper.toProcessDomain(foundProcessEntity, foundThreadEntities);
     }
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/bidding/BiddingProcessAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/bidding/BiddingProcessAdapter.java
@@ -8,45 +8,44 @@ import com.peauty.persistence.bidding.process.BiddingProcessEntity;
 import com.peauty.persistence.bidding.process.BiddingProcessRepository;
 import com.peauty.persistence.bidding.thread.BiddingThreadEntity;
 import com.peauty.persistence.bidding.thread.BiddingThreadRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class BiddingProcessAdapter implements BiddingProcessPort {
 
-    private final BiddingProcessRepository biddingProcessRepository;
-    private final BiddingThreadRepository biddingThreadRepository;
-
-    @Override
-    public BiddingProcess getProcessById(Long processId) {
-        BiddingProcessEntity foundProcessEntity = biddingProcessRepository.findById(processId)
-                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_FOUND_BIDDING_PROCESS));
-        List<BiddingThreadEntity> foundBiddingThreadEntities = biddingThreadRepository.findByBiddingProcessId(processId);
-        return BiddingMapper.toProcessDomain(foundProcessEntity, foundBiddingThreadEntities);
-    }
+    private final BiddingProcessRepository processRepository;
+    private final BiddingThreadRepository threadRepository;
+    @PersistenceContext private EntityManager em;
 
     @Override
     public BiddingProcess save(BiddingProcess process) {
-        checkInitProcess(process);
-        BiddingProcessEntity processEntityToSave = BiddingMapper.toProcessEntity(process);
-        List<BiddingThreadEntity> threadEntitiesToSave = BiddingMapper.toThreadEntities(process.getThreads());
-        BiddingProcessEntity savedProcessEntity = biddingProcessRepository.save(processEntityToSave);
-        List<BiddingThreadEntity> savedThreadEntities = biddingThreadRepository.saveAll(threadEntitiesToSave);
-        return BiddingMapper.toProcessDomain(savedProcessEntity, savedThreadEntities);
+        BiddingProcessEntity savedProcessEntity = processRepository.save(
+                BiddingMapper.toProcessEntity(process)
+        );
+
+        List<BiddingThreadEntity> threadEntities = process.getThreads().stream()
+                .map(thread -> BiddingMapper.toThreadEntity(thread, savedProcessEntity))
+                .toList();
+
+        List<BiddingThreadEntity> savedThreads = threadRepository.saveAll(threadEntities);
+        savedProcessEntity.setThreads(savedThreads);
+
+        return BiddingMapper.toProcessDomain(savedProcessEntity);
     }
 
     @Override
-    public BiddingProcess initProcess(BiddingProcess process) {
-        BiddingProcessEntity processEntityToSave = BiddingMapper.toProcessEntity(process);
-        BiddingProcessEntity savedProcessEntity = biddingProcessRepository.save(processEntityToSave);
-        return BiddingMapper.toProcessDomain(savedProcessEntity, List.of());
-    }
+    public BiddingProcess getProcessById(Long processId) {
+        BiddingProcessEntity foundProcessEntity = processRepository.findByIdWithThread(processId)
+                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_FOUND_BIDDING_PROCESS));
 
-    // TODO init 을 강제하기 위함인데.. 다른 방법이 있나 알아보기
-    private void checkInitProcess(BiddingProcess process) {
-        process.getId().orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_INITIALIZED_PROCESS));
+        return BiddingMapper.toProcessDomain(foundProcessEntity);
     }
 }

--- a/peauty-domain/src/main/java/com/peauty/domain/bidding/BiddingThread.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/bidding/BiddingThread.java
@@ -1,9 +1,11 @@
 package com.peauty.domain.bidding;
 
+import com.peauty.domain.customer.Customer;
 import com.peauty.domain.exception.PeautyException;
 import com.peauty.domain.response.PeautyResponseCode;
 import lombok.*;
 
+import java.nio.file.attribute.UserPrincipal;
 import java.util.Optional;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -45,6 +47,14 @@ public class BiddingThread {
     }
 
     protected void registerBelongingProcessObserver(BiddingProcess belongingProcess) {
+
+        // 새로운 프로세스-스레드 생성 케이스
+        if (belongingProcess.getId().isEmpty() && this.processId == null) {
+            this.belongingProcessObserver = belongingProcess;
+            return;
+        }
+
+        // 저장된 프로세스-스레드 연결 케이스
         Long processId = belongingProcess.getId()
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.PROCESS_NOT_REGISTERED))
                 .value();

--- a/peauty-persistence/src/main/java/com/peauty/persistence/bidding/process/BiddingProcessEntity.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/bidding/process/BiddingProcessEntity.java
@@ -1,13 +1,10 @@
 package com.peauty.persistence.bidding.process;
 
 import com.peauty.domain.bidding.BiddingProcessStatus;
-import com.peauty.persistence.bidding.thread.BiddingThreadEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "bidding_process")
@@ -33,12 +30,4 @@ public class BiddingProcessEntity {
 
     @Column(name = "status_modified_at", nullable = false)
     private LocalDateTime statusModifiedAt;
-
-    @OneToMany(mappedBy = "biddingProcess", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
-    private List<BiddingThreadEntity> threads = new ArrayList<>();
-
-    public void setThreads(List<BiddingThreadEntity> threads) {
-        this.threads = new ArrayList<>(threads);
-    }
 }

--- a/peauty-persistence/src/main/java/com/peauty/persistence/bidding/process/BiddingProcessEntity.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/bidding/process/BiddingProcessEntity.java
@@ -1,11 +1,13 @@
 package com.peauty.persistence.bidding.process;
 
 import com.peauty.domain.bidding.BiddingProcessStatus;
-import com.peauty.domain.bidding.BiddingProcessTimeInfo;
+import com.peauty.persistence.bidding.thread.BiddingThreadEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "bidding_process")
@@ -31,4 +33,12 @@ public class BiddingProcessEntity {
 
     @Column(name = "status_modified_at", nullable = false)
     private LocalDateTime statusModifiedAt;
+
+    @OneToMany(mappedBy = "biddingProcess", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<BiddingThreadEntity> threads = new ArrayList<>();
+
+    public void setThreads(List<BiddingThreadEntity> threads) {
+        this.threads = new ArrayList<>(threads);
+    }
 }

--- a/peauty-persistence/src/main/java/com/peauty/persistence/bidding/process/BiddingProcessRepository.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/bidding/process/BiddingProcessRepository.java
@@ -11,21 +11,13 @@ import java.util.Optional;
 @Repository
 public interface BiddingProcessRepository extends JpaRepository<BiddingProcessEntity, Long> {
 
-    List<BiddingProcessEntity> findByPuppyId(Long puppyId);
+    @Query("SELECT p FROM BiddingProcessEntity p " +
+            "LEFT JOIN FETCH p.threads " +
+            "WHERE p.puppyId = :puppyId")
+    List<BiddingProcessEntity> findByPuppyIdWithThread(@Param("puppyId") Long puppyId);
 
-    @Query("""
-            SELECT p\s
-            FROM BiddingProcessEntity p, BiddingThreadEntity t\s
-            WHERE t.biddingProcessId = p.id\s
-            AND t.id = :threadId
-            """)
-    Optional<BiddingProcessEntity> findByThreadId(@Param("threadId") Long threadId);
-
-    @Query("""
-            SELECT DISTINCT p\s
-            FROM BiddingProcessEntity p, BiddingThreadEntity t\s
-            WHERE t.biddingProcessId = p.id\s
-            AND t.designerId = :designerId
-            """)
-    List<BiddingProcessEntity> findAllByDesignerId(@Param("designerId") Long designerId);
+    @Query("SELECT p FROM BiddingProcessEntity p " +
+            "LEFT JOIN FETCH p.threads " +
+            "WHERE p.id = :id")
+    Optional<BiddingProcessEntity> findByIdWithThread(@Param("id") Long id);
 }

--- a/peauty-persistence/src/main/java/com/peauty/persistence/bidding/process/BiddingProcessRepository.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/bidding/process/BiddingProcessRepository.java
@@ -1,23 +1,13 @@
 package com.peauty.persistence.bidding.process;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface BiddingProcessRepository extends JpaRepository<BiddingProcessEntity, Long> {
 
-    @Query("SELECT p FROM BiddingProcessEntity p " +
-            "LEFT JOIN FETCH p.threads " +
-            "WHERE p.puppyId = :puppyId")
-    List<BiddingProcessEntity> findByPuppyIdWithThread(@Param("puppyId") Long puppyId);
-
-    @Query("SELECT p FROM BiddingProcessEntity p " +
-            "LEFT JOIN FETCH p.threads " +
-            "WHERE p.id = :id")
-    Optional<BiddingProcessEntity> findByIdWithThread(@Param("id") Long id);
+    List<BiddingProcessEntity> findByPuppyId(@Param("puppyId") Long puppyId);
 }

--- a/peauty-persistence/src/main/java/com/peauty/persistence/bidding/thread/BiddingThreadEntity.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/bidding/thread/BiddingThreadEntity.java
@@ -3,6 +3,7 @@ package com.peauty.persistence.bidding.thread;
 import com.peauty.domain.bidding.BiddingThreadStatus;
 import com.peauty.domain.bidding.BiddingThreadStep;
 import com.peauty.domain.bidding.BiddingThreadTimeInfo;
+import com.peauty.persistence.bidding.process.BiddingProcessEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -20,8 +21,9 @@ public class BiddingThreadEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "bidding_process_id", nullable = false)
-    private Long biddingProcessId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bidding_process_id", nullable = false)
+    private BiddingProcessEntity biddingProcess;
 
     @Column(name = "designer_id", nullable = false)
     private Long designerId;


### PR DESCRIPTION
## 📄 [PEAUTY-124] JPA mapping between processes and threads

Jira : [PEAUTY-124](https://multicampusuplus.atlassian.net/browse/PEAUTY-124?atlOrigin=eyJpIjoiOGZhYTJmMWQ2ZjFjNDVkZDkyMmEwYTY3ZTI2NmNiZDkiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명

- 프로세스와 스레드 간 JPA 매핑을 통해 프로세스로 스레드를 불러오는 것이 쉽게 가능해졌습니다
- 프로세스를 로드할 필요가 없어졌습니다

<!-- Pull Request의 설명을 추가하세요. -->

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.5 MD
- Actual MD: 0.5 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
