### PR TITLE
[PEAUTY-150] Add Column 'color' in Badge

### DIFF
--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/dto/GetAroundWorkspaceResult.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/dto/GetAroundWorkspaceResult.java
@@ -3,7 +3,6 @@ package com.peauty.customer.business.customer.dto;
 import com.peauty.domain.designer.*;
 
 import java.util.List;
-import java.util.Optional;
 
 public record GetAroundWorkspaceResult(
         Long workspaceId,

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/designer/DesignerAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/designer/DesignerAdapter.java
@@ -28,6 +28,7 @@ public class DesignerAdapter implements DesignerPort {
                         .badgeContent(badgeEntity.getBadgeContent())
                         .badgeImageUrl(badgeEntity.getBadgeImageUrl())
                         .isRepresentativeBadge(true)
+                        .badgeColor(badgeEntity.getColor())
                         .build())
                 .collect(Collectors.toList());
     }
@@ -41,6 +42,7 @@ public class DesignerAdapter implements DesignerPort {
                         .badgeName(badgeEntity.getBadgeName())
                         .badgeContent(badgeEntity.getBadgeContent())
                         .badgeImageUrl(badgeEntity.getBadgeImageUrl())
+//                        .badgeColor(badgeEntity.getColor())
                         .build())
                 .toList();
     }
@@ -65,6 +67,7 @@ public class DesignerAdapter implements DesignerPort {
                             .badgeContent(badgeEntity.getBadgeContent())
                             .badgeImageUrl(badgeEntity.getBadgeImageUrl())
                             .isRepresentativeBadge(isRepresentative)
+                            .badgeColor(badgeEntity.getColor())
                             .build();
                 })
                 .toList();

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/designer/DesignerAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/designer/DesignerAdapter.java
@@ -28,7 +28,7 @@ public class DesignerAdapter implements DesignerPort {
                         .badgeContent(badgeEntity.getBadgeContent())
                         .badgeImageUrl(badgeEntity.getBadgeImageUrl())
                         .isRepresentativeBadge(true)
-                        .badgeColor(badgeEntity.getColor())
+                        .badgeColor(badgeEntity.getBadgeColor())
                         .build())
                 .collect(Collectors.toList());
     }
@@ -42,7 +42,7 @@ public class DesignerAdapter implements DesignerPort {
                         .badgeName(badgeEntity.getBadgeName())
                         .badgeContent(badgeEntity.getBadgeContent())
                         .badgeImageUrl(badgeEntity.getBadgeImageUrl())
-//                        .badgeColor(badgeEntity.getColor())
+//                        .badgeColor(badgeEntity.getBadgeColor())
                         .build())
                 .toList();
     }
@@ -67,7 +67,7 @@ public class DesignerAdapter implements DesignerPort {
                             .badgeContent(badgeEntity.getBadgeContent())
                             .badgeImageUrl(badgeEntity.getBadgeImageUrl())
                             .isRepresentativeBadge(isRepresentative)
-                            .badgeColor(badgeEntity.getColor())
+                            .badgeColor(badgeEntity.getBadgeColor())
                             .build();
                 })
                 .toList();

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetDesignerBadgesForCustomerResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetDesignerBadgesForCustomerResponse.java
@@ -2,7 +2,7 @@ package com.peauty.customer.presentation.controller.customer.dto;
 
 import com.peauty.customer.business.customer.dto.GetDesignerBadgesForCustomerResult;
 import com.peauty.domain.designer.Badge;
-import com.peauty.domain.designer.Color;
+import com.peauty.domain.designer.BadgeColor;
 
 import java.util.List;
 
@@ -26,7 +26,7 @@ public record GetDesignerBadgesForCustomerResponse(
             String badgeName,
             String badgeContent,
             String badgeImageUrl,
-            Color color
+            BadgeColor badgeColor
     ) {
         public static BadgeResponse from(Badge badge) {
             return new BadgeResponse(

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetDesignerBadgesForCustomerResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetDesignerBadgesForCustomerResponse.java
@@ -2,6 +2,7 @@ package com.peauty.customer.presentation.controller.customer.dto;
 
 import com.peauty.customer.business.customer.dto.GetDesignerBadgesForCustomerResult;
 import com.peauty.domain.designer.Badge;
+import com.peauty.domain.designer.Color;
 
 import java.util.List;
 
@@ -24,14 +25,16 @@ public record GetDesignerBadgesForCustomerResponse(
             Long badgeId,
             String badgeName,
             String badgeContent,
-            String badgeImageUrl
+            String badgeImageUrl,
+            Color color
     ) {
         public static BadgeResponse from(Badge badge) {
             return new BadgeResponse(
                     badge.getBadgeId(),
                     badge.getBadgeName(),
                     badge.getBadgeContent(),
-                    badge.getBadgeImageUrl()
+                    badge.getBadgeImageUrl(),
+                    badge.getBadgeColor()
             );
         }
     }

--- a/peauty-designer-api/src/main/java/com/peauty/designer/implementation/designer/DesignerAdapter.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/implementation/designer/DesignerAdapter.java
@@ -110,7 +110,7 @@ public class DesignerAdapter implements DesignerPort {
                         .badgeName(badgeEntity.getBadgeName())
                         .badgeContent(badgeEntity.getBadgeContent())
                         .badgeImageUrl(badgeEntity.getBadgeImageUrl())
-                        .badgeColor(badgeEntity.getColor())
+                        .badgeColor(badgeEntity.getBadgeColor())
                         .isRepresentativeBadge(true)
                         .build())
                 .collect(Collectors.toList());
@@ -147,7 +147,7 @@ public class DesignerAdapter implements DesignerPort {
                             .badgeName(badgeEntity.getBadgeName())
                             .badgeContent(badgeEntity.getBadgeContent())
                             .badgeImageUrl(badgeEntity.getBadgeImageUrl())
-                            .badgeColor(badgeEntity.getColor())
+                            .badgeColor(badgeEntity.getBadgeColor())
                             .isRepresentativeBadge(isRepresentative)
                             .build();
                 })

--- a/peauty-designer-api/src/main/java/com/peauty/designer/implementation/designer/DesignerAdapter.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/implementation/designer/DesignerAdapter.java
@@ -110,6 +110,7 @@ public class DesignerAdapter implements DesignerPort {
                         .badgeName(badgeEntity.getBadgeName())
                         .badgeContent(badgeEntity.getBadgeContent())
                         .badgeImageUrl(badgeEntity.getBadgeImageUrl())
+                        .badgeColor(badgeEntity.getColor())
                         .isRepresentativeBadge(true)
                         .build())
                 .collect(Collectors.toList());
@@ -146,6 +147,7 @@ public class DesignerAdapter implements DesignerPort {
                             .badgeName(badgeEntity.getBadgeName())
                             .badgeContent(badgeEntity.getBadgeContent())
                             .badgeImageUrl(badgeEntity.getBadgeImageUrl())
+                            .badgeColor(badgeEntity.getColor())
                             .isRepresentativeBadge(isRepresentative)
                             .build();
                 })

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/dto/GetDesignerBadgesResponse.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/dto/GetDesignerBadgesResponse.java
@@ -2,6 +2,7 @@ package com.peauty.designer.presentation.controller.designer.dto;
 
 import com.peauty.designer.business.designer.dto.GetDesignerBadgesResult;
 import com.peauty.domain.designer.Badge;
+import com.peauty.domain.designer.Color;
 
 import java.util.List;
 
@@ -22,14 +23,16 @@ public record GetDesignerBadgesResponse(
             Long badgeId,
             String badgeName,
             String badgeContent,
-            String badgeImageUrl
+            String badgeImageUrl,
+            Color color
     ) {
         public static BadgeResponse from(Badge badge) {
             return new BadgeResponse(
                     badge.getBadgeId(),
                     badge.getBadgeName(),
                     badge.getBadgeContent(),
-                    badge.getBadgeImageUrl()
+                    badge.getBadgeImageUrl(),
+                    badge.getBadgeColor()
             );
         }
     }

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/dto/GetDesignerBadgesResponse.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/dto/GetDesignerBadgesResponse.java
@@ -2,7 +2,7 @@ package com.peauty.designer.presentation.controller.designer.dto;
 
 import com.peauty.designer.business.designer.dto.GetDesignerBadgesResult;
 import com.peauty.domain.designer.Badge;
-import com.peauty.domain.designer.Color;
+import com.peauty.domain.designer.BadgeColor;
 
 import java.util.List;
 
@@ -24,7 +24,7 @@ public record GetDesignerBadgesResponse(
             String badgeName,
             String badgeContent,
             String badgeImageUrl,
-            Color color
+            BadgeColor badgeColor
     ) {
         public static BadgeResponse from(Badge badge) {
             return new BadgeResponse(

--- a/peauty-domain/src/main/java/com/peauty/domain/designer/Badge.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/designer/Badge.java
@@ -14,5 +14,6 @@ public class Badge {
     private String badgeContent;
     private String badgeImageUrl;
     private Boolean isRepresentativeBadge;
+    private Color badgeColor;
 
 }

--- a/peauty-domain/src/main/java/com/peauty/domain/designer/Badge.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/designer/Badge.java
@@ -14,6 +14,6 @@ public class Badge {
     private String badgeContent;
     private String badgeImageUrl;
     private Boolean isRepresentativeBadge;
-    private Color badgeColor;
+    private BadgeColor badgeColor;
 
 }

--- a/peauty-domain/src/main/java/com/peauty/domain/designer/BadgeColor.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/designer/BadgeColor.java
@@ -2,10 +2,12 @@ package com.peauty.domain.designer;
 
 import com.peauty.domain.exception.PeautyException;
 import com.peauty.domain.response.PeautyResponseCode;
+import lombok.Getter;
 
 import java.util.Arrays;
 
-public enum Color {
+@Getter
+public enum BadgeColor {
 
     BLUE("블루"),
     GREEN("그린"),
@@ -13,17 +15,17 @@ public enum Color {
     SILVER("실버"),
     GOLD("골드");
 
-    private final String badgeColor;
+    private final String colorName;
 
-    Color(String badgeColor) {
-        this.badgeColor = badgeColor;
+    BadgeColor(String colorName) {
+        this.colorName = colorName;
     }
-    public static Color from(String color){
-        return Arrays.stream(Color.values())
-                .filter(it -> it.badgeColor.equalsIgnoreCase(color))
+
+    public static BadgeColor from(String badgeColor){
+        return Arrays.stream(BadgeColor.values())
+                .filter(it -> it.colorName.equalsIgnoreCase(badgeColor))
                 .findFirst()
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.INVALID_COLOR_OPTION));
+
     }
-
-
 }

--- a/peauty-domain/src/main/java/com/peauty/domain/designer/Color.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/designer/Color.java
@@ -1,0 +1,29 @@
+package com.peauty.domain.designer;
+
+import com.peauty.domain.exception.PeautyException;
+import com.peauty.domain.response.PeautyResponseCode;
+
+import java.util.Arrays;
+
+public enum Color {
+
+    BLUE("블루"),
+    GREEN("그린"),
+    BRONZE("브론즈"),
+    SILVER("실버"),
+    GOLD("골드");
+
+    private final String badgeColor;
+
+    Color(String badgeColor) {
+        this.badgeColor = badgeColor;
+    }
+    public static Color from(String color){
+        return Arrays.stream(Color.values())
+                .filter(it -> it.badgeColor.equalsIgnoreCase(color))
+                .findFirst()
+                .orElseThrow(() -> new PeautyException(PeautyResponseCode.INVALID_COLOR_OPTION));
+    }
+
+
+}

--- a/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
@@ -38,6 +38,7 @@ public enum PeautyResponseCode {
     NOT_EXIST_DESIGNER("1216", "Designer Not Found", "찾을 수 없는 디자이너입니다."),
     INVALID_LICENSE_VERIFICATION_OPTION("1217", "Invalid License Verification Option", "잘못된 자격증 검증 옵션입니다."),
     INVALID_SCISSORS_RANK_OPTION("1218", "Invalid Scissors Rank Option", "잘못된 시저 랭크 옵션입니다."),
+    INVALID_COLOR_OPTION("1219", "Invalid Color Option", "잘못된 컬러 옵션입니다."),
 
     // 비딩 관련 (1300 ~ 1350)
     WRONG_BIDDING_PROCESS_STEP_DESCRIPTION("1300", "Wrong Bidding Process Step Description", "잘못된 입찰 프로세스입니다."),

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/BadgeEntity.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/BadgeEntity.java
@@ -1,5 +1,6 @@
 package com.peauty.persistence.designer;
 
+import com.peauty.domain.designer.Color;
 import com.peauty.persistence.config.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -25,5 +26,9 @@ public class BadgeEntity extends BaseTimeEntity {
     @Lob
     @Column(name = "badge_image_url", nullable = false)
     private String badgeImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "color", nullable = false)
+    private Color color;
 
 }

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/BadgeEntity.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/BadgeEntity.java
@@ -1,6 +1,6 @@
 package com.peauty.persistence.designer;
 
-import com.peauty.domain.designer.Color;
+import com.peauty.domain.designer.BadgeColor;
 import com.peauty.persistence.config.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -28,7 +28,7 @@ public class BadgeEntity extends BaseTimeEntity {
     private String badgeImageUrl;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "color", nullable = false)
-    private Color color;
+    @Column(name = "badge_color", nullable = false)
+    private BadgeColor badgeColor;
 
 }


### PR DESCRIPTION
## 📄 [PEAUTY-150] Add Column 'color' in Badge

Jira : [PEAUTY-150](https://multicampusuplus.atlassian.net/browse/PEAUTY-150?atlOrigin=eyJpIjoiN2Y2MjFlNzdhMzE2NDFmZmI1YTdjMGNhNDI0MjM3YWIiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명
- [x] 버그 수정 설명
- [x] 문서 수정 설명

<!-- Pull Request의 설명을 추가하세요. -->
프론트 측에서 추가 요구한 뱃지의 컬러 컬럼입니다.
GREEN, BLUE, BRONZE, SILVER, GOLD로 enum에서 정의했습니다.
그 외에는 뱃지를 조회하는 곳에서 뱃지의 컬러를 가져올 수 있도록 조치했습니다.

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD:  0.1 MD
- Actual MD: 0.1 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
