### PR TITLE
[PEAUTY-143] update Designer's Badges Option

### DIFF
--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerPort.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerPort.java
@@ -28,5 +28,7 @@ public interface DesignerPort {
 
     List<Badge> getAcquiredBadges(Long userId);
 
+    void updateBadgeStatus(Badge badge, Long userId);
+
 }
 

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerService.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerService.java
@@ -12,4 +12,5 @@ public interface DesignerService {
     GetDesignerWorkspaceResult getDesignerWorkspace(Long workspaceId);
     UpdateDesignerWorkspaceResult updateDesignerWorkspace(Long userId, UpdateDesignerWorkspaceCommand command);
     GetDesignerBadgesResult getDesignerBadges(Long designerId);
+    UpdateRepresentativeBadgeResult updateRepresentativeBadge(Long userId, Long badgeId, UpdateRepresentativeBadgeCommand command);
 }

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerServiceImpl.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerServiceImpl.java
@@ -126,8 +126,6 @@ public class DesignerServiceImpl implements DesignerService {
     @Transactional
     @Override
     public UpdateRepresentativeBadgeResult updateRepresentativeBadge(Long userId, Long badgeId, UpdateRepresentativeBadgeCommand command) {
-        // 디자이너와 획득한 뱃지 조회
-        Designer designer = designerPort.getByDesignerId(userId);
         List<Badge> acquiredBadges = designerPort.getAcquiredBadges(userId);
 
         // 기존 대표 뱃지 확인

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateRepresentativeBadgeCommand.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateRepresentativeBadgeCommand.java
@@ -1,0 +1,23 @@
+package com.peauty.designer.business.designer.dto;
+
+import com.peauty.domain.designer.Badge;
+
+public record UpdateRepresentativeBadgeCommand(
+// TODO: 프론트 화면이 안 나와서 주석처리
+//        String badgeName,
+//        String badgeContent,
+//        String badgeImageUrl,
+        boolean isRepresentativeBadge
+//        BadgeColor badgeColor
+) {
+    public static Badge toBadge(UpdateRepresentativeBadgeCommand command){
+        return Badge.builder()
+// TODO: 프론트 화면이 안 나와서 주석처리
+//                .badgeName(command.badgeName())
+//                .badgeContent(command.badgeContent())
+//                .badgeImageUrl(command.badgeImageUrl())
+                .isRepresentativeBadge(command.isRepresentativeBadge())
+//                .badgeColor(command.badgeColor())
+                .build();
+    }
+}

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateRepresentativeBadgeResult.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateRepresentativeBadgeResult.java
@@ -1,0 +1,17 @@
+package com.peauty.designer.business.designer.dto;
+
+public record UpdateRepresentativeBadgeResult(
+        Long badgeId,
+        String badgeName,
+        boolean isRepresentativeBadge
+) {
+    public static UpdateRepresentativeBadgeResult from(Long badgeId,
+                                                       String badgeName,
+                                                       boolean isRepresentativeBadge) {
+
+        return new UpdateRepresentativeBadgeResult(
+                badgeId,
+                badgeName,
+                isRepresentativeBadge);
+    }
+}

--- a/peauty-designer-api/src/main/java/com/peauty/designer/implementation/designer/DesignerAdapter.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/implementation/designer/DesignerAdapter.java
@@ -10,12 +10,10 @@ import com.peauty.domain.response.PeautyResponseCode;
 import com.peauty.domain.user.Role;
 import com.peauty.domain.user.Status;
 import com.peauty.persistence.designer.*;
-import com.peauty.persistence.designer.badge.BadgeEntity;
-import com.peauty.persistence.designer.badge.BadgeRepository;
-import com.peauty.persistence.designer.badge.DesignerBadgeEntity;
-import com.peauty.persistence.designer.badge.DesignerBadgeRepository;
+import com.peauty.persistence.designer.badge.*;
 import com.peauty.persistence.designer.license.LicenseEntity;
 import com.peauty.persistence.designer.license.LicenseRepository;
+import com.peauty.persistence.designer.mapper.BadgeMapper;
 import com.peauty.persistence.designer.mapper.DesignerMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -161,6 +159,16 @@ public class DesignerAdapter implements DesignerPort {
                 .toList();
     }
 
+    @Override
+    public void updateBadgeStatus(Badge badge, Long userId) {
+        DesignerBadgeEntity existingBadgeEntity = designerBadgeRepository
+                .findByDesignerIdAndBadgeId(userId, badge.getBadgeId())
+                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_BADGE));
+        // 업데이트 엔티티
+        DesignerBadgeEntity updatedBadgeEntity = BadgeMapper.updateEntity(existingBadgeEntity, badge);
+        // 엔티티 저장
+        designerBadgeRepository.save(updatedBadgeEntity);
+    }
 
 
 }

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/DesignerController.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/DesignerController.java
@@ -73,5 +73,16 @@ public class DesignerController {
         return GetDesignerBadgesResponse.from(result);
     }
 
+    @PutMapping("/{userId}/badges/{badgeId}/representative")
+    @Operation(summary = "디자이너 대표 뱃지 설정", description = "디자이너가 본인이 가진 뱃지 중 대표 뱃지로 설정하는 API입니다.")
+    public UpdateRepresentativeBadgeResponse updateRepresentativeBadge(@PathVariable Long userId,
+                                                                       @PathVariable Long badgeId,
+                                                                       @RequestBody UpdateRepresentativeBadgeRequest request){
+
+        UpdateRepresentativeBadgeResult result = designerService.updateRepresentativeBadge(userId, badgeId, request.toCommand());
+        return UpdateRepresentativeBadgeResponse.from(result);
+    }
+
+
 }
 

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/dto/UpdateRepresentativeBadgeRequest.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/dto/UpdateRepresentativeBadgeRequest.java
@@ -1,0 +1,24 @@
+package com.peauty.designer.presentation.controller.designer.dto;
+
+
+import com.peauty.designer.business.designer.dto.UpdateRepresentativeBadgeCommand;
+
+public record UpdateRepresentativeBadgeRequest(
+// TODO: 프론트 화면이 안 나와서 주석처리
+//      String badgeName,
+//      String badgeContent,
+//      String badgeImageUrl,
+      boolean isRepresentativeBadge
+//      BadgeColor badgeColor
+) {
+    public UpdateRepresentativeBadgeCommand toCommand() {
+        return new UpdateRepresentativeBadgeCommand(
+// TODO: 프론트 화면이 안 나와서 주석처리
+//                this.badgeName,
+//                this.badgeContent,
+//                this.badgeImageUrl,
+                this.isRepresentativeBadge
+//                this.badgeColor
+        );
+    }
+}

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/dto/UpdateRepresentativeBadgeResponse.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/dto/UpdateRepresentativeBadgeResponse.java
@@ -1,0 +1,17 @@
+package com.peauty.designer.presentation.controller.designer.dto;
+
+import com.peauty.designer.business.designer.dto.UpdateRepresentativeBadgeResult;
+
+public record UpdateRepresentativeBadgeResponse(
+        Long badgeId,
+        String badgeName,
+        boolean isRepresentativeBadge
+) {
+    public static UpdateRepresentativeBadgeResponse from(UpdateRepresentativeBadgeResult result){
+        return new UpdateRepresentativeBadgeResponse(
+                result.badgeId(),
+                result.badgeName(),
+                result.isRepresentativeBadge()
+        );
+    }
+}

--- a/peauty-domain/src/main/java/com/peauty/domain/designer/Badge.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/designer/Badge.java
@@ -16,4 +16,8 @@ public class Badge {
     private Boolean isRepresentativeBadge;
     private BadgeColor badgeColor;
 
+    public void updateIsRepresentativeBadge(boolean isRepresentativeBadge) {
+        this.isRepresentativeBadge = isRepresentativeBadge;
+    }
+
 }

--- a/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
@@ -39,6 +39,8 @@ public enum PeautyResponseCode {
     INVALID_LICENSE_VERIFICATION_OPTION("1217", "Invalid License Verification Option", "잘못된 자격증 검증 옵션입니다."),
     INVALID_SCISSORS_RANK_OPTION("1218", "Invalid Scissors Rank Option", "잘못된 시저 랭크 옵션입니다."),
     INVALID_COLOR_OPTION("1219", "Invalid Color Option", "잘못된 컬러 옵션입니다."),
+    ALREADY_FULL_BADGE("1220", "Already Full Representative Badge", "이미 대표 뱃지가 3개입니다."),
+    NOT_EXIST_BADGE("1221", "Not Exist Badge", "해당 뱃지를 찾을 수 없습니다."),
 
     // 비딩 관련 (1300 ~ 1350)
     WRONG_BIDDING_PROCESS_STEP_DESCRIPTION("1300", "Wrong Bidding Process Step Description", "잘못된 입찰 프로세스입니다."),

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/badge/DesignerBadgeRepository.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/badge/DesignerBadgeRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface DesignerBadgeRepository extends JpaRepository<DesignerBadgeEntity, Long> {
@@ -15,5 +16,7 @@ public interface DesignerBadgeRepository extends JpaRepository<DesignerBadgeEnti
     List<DesignerBadgeEntity> findAllByDesignerIdAndIsRepresentativeBadge(Long designerId, boolean isRepresentativeBadge);
 
     List<DesignerBadgeEntity> findAllByDesignerId(Long designerId);
+
+    Optional<DesignerBadgeEntity> findByDesignerIdAndBadgeId(Long designerId, Long badgeId);
 
 }

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/mapper/BadgeMapper.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/mapper/BadgeMapper.java
@@ -1,0 +1,65 @@
+package com.peauty.persistence.designer.mapper;
+
+import com.peauty.domain.designer.Badge;
+import com.peauty.persistence.designer.badge.BadgeEntity;
+import com.peauty.persistence.designer.badge.DesignerBadgeEntity;
+
+public class BadgeMapper {
+
+    public BadgeMapper(){
+        // private 생성자로 인스턴스화 방지
+    }
+
+    // 엔티티 -> 도메인
+    public static Badge toBadgeDomain(BadgeEntity entity) {
+        return Badge.builder()
+                .badgeId(entity.getId())
+                .badgeName(entity.getBadgeName())
+                .badgeContent(entity.getBadgeContent())
+                .badgeImageUrl(entity.getBadgeImageUrl())
+                .badgeColor(entity.getBadgeColor())
+                .build();
+    }
+
+    // 도메인 -> 엔티티
+    public static BadgeEntity toBadgeEntity(Badge domain) {
+        return BadgeEntity.builder()
+                .id(domain.getBadgeId())
+                .badgeName(domain.getBadgeName())
+                .badgeContent(domain.getBadgeContent())
+                .badgeImageUrl(domain.getBadgeImageUrl())
+                .badgeColor(domain.getBadgeColor())
+                .build();
+    }
+
+    // 엔티티 -> 도메인
+    public static Badge toDesignerBadgeDomain(DesignerBadgeEntity entity) {
+        return Badge.builder()
+                .badgeId(entity.getBadgeId())
+                .isRepresentativeBadge(entity.isRepresentativeBadge())
+                .build();
+    }
+
+    // 도메인 -> 엔티티
+    public static DesignerBadgeEntity toDesignerBadgeEntity(Badge domain, Long designerId) {
+        return DesignerBadgeEntity.builder()
+                .designerId(designerId)
+                .badgeId(domain.getBadgeId())
+                .isRepresentativeBadge(domain.getIsRepresentativeBadge())
+                .build();
+    }
+
+    // 기존 엔티티를 업데이트하는 메서드
+    public static DesignerBadgeEntity updateEntity(DesignerBadgeEntity Entity, Badge badge) {
+        return DesignerBadgeEntity.builder()
+                .id(Entity.getId()) // ID 유지
+                .designerId(Entity.getDesignerId()) // 디자이너 ID 유지
+                .badgeId(Entity.getBadgeId()) // 뱃지 ID 유지
+                .isRepresentativeBadge(badge.getIsRepresentativeBadge()) // 대표 뱃지 업데이트
+                .build();
+    }
+
+
+}
+
+


### PR DESCRIPTION
## 📄 [PEAUTY-143] update Designer's Badges Option

Jira : [PEAUTY-143](https://multicampusuplus.atlassian.net/browse/PEAUTY-143?atlOrigin=eyJpIjoiYjU0MDhhZTNiZTU4NGZkMmJjNTZlOTQxZDViYWU4MjQiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명
- [x] 버그 수정 설명
- [x] 문서 수정 설명

<!-- Pull Request의 설명을 추가하세요. -->
디자이너는 본인의 뱃지의 상태를 설정할 수 있습니다. 설정가능한 옵션은 대표뱃지입니다.
대표뱃지는 최대 3개까지만 설정이 가능하며 그 이상 설정할 수 없도록 로직 설정했습니다.


## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.2 MD
- Actual MD: 0.4 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
