### PR TITLE
[PEAUTY-155] Designer profile -> account

### DIFF
--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerService.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerService.java
@@ -5,8 +5,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface DesignerService {
     UploadProfileImageResult uploadProfileImage(Long userId, MultipartFile file);
-    GetDesignerProfileResult getDesignerProfile(Long designerId);
-    UpdateDesignerProfileResult updateDesignerProfile(Long designerId, UpdateDesignerProfileCommand command);
+    GetDesignerAccountResult getDesignerAccount(Long designerId);
+    UpdateDesignerAccountResult updateDesignerAccount(Long designerId, UpdateDesignerAccountCommand command);
     void checkDesignerNicknameDuplicated(String nickname);
     CreateDesignerWorkspaceResult createDesignerWorkspace(Long userId, CreateDesignerWorkspaceCommand command);
     GetDesignerWorkspaceResult getDesignerWorkspace(Long workspaceId);

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerServiceImpl.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerServiceImpl.java
@@ -35,14 +35,14 @@ public class DesignerServiceImpl implements DesignerService {
     }
 
     @Override
-    public GetDesignerProfileResult getDesignerProfile(Long designerId) {
+    public GetDesignerAccountResult getDesignerAccount(Long designerId) {
         Designer designer = designerPort.getByDesignerId(designerId);
-        return GetDesignerProfileResult.from(designer);
+        return GetDesignerAccountResult.from(designer);
     }
 
     @Override
     @Transactional
-    public UpdateDesignerProfileResult updateDesignerProfile(Long designerId, UpdateDesignerProfileCommand command) {
+    public UpdateDesignerAccountResult updateDesignerAccount(Long designerId, UpdateDesignerAccountCommand command) {
         Designer designerToUpdate = designerPort.getByDesignerId(designerId);
         designerToUpdate.updateName(command.name());
         designerToUpdate.updatePhoneNumber(command.phoneNumber());
@@ -50,7 +50,7 @@ public class DesignerServiceImpl implements DesignerService {
         designerToUpdate.updateProfileImageUrl(command.profileImageUrl());
         designerToUpdate.updateEmail(command.email());
         Designer updatedDesigner = designerPort.save(designerToUpdate);
-        return UpdateDesignerProfileResult.from(updatedDesigner);
+        return UpdateDesignerAccountResult.from(updatedDesigner);
     }
 
     @Override

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/GetDesignerAccountResult.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/GetDesignerAccountResult.java
@@ -2,7 +2,7 @@ package com.peauty.designer.business.designer.dto;
 
 import com.peauty.domain.designer.Designer;
 
-public record GetDesignerProfileResult(
+public record GetDesignerAccountResult(
         Long designerId,
         String name,
         String nickname,
@@ -11,8 +11,8 @@ public record GetDesignerProfileResult(
         String phoneNumber
 ) {
 
-    public static GetDesignerProfileResult from(Designer designer){
-        return new GetDesignerProfileResult(
+    public static GetDesignerAccountResult from(Designer designer){
+        return new GetDesignerAccountResult(
                 designer.getDesignerId(),
                 designer.getName(),
                 designer.getNickname(),

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateDesignerAccountCommand.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateDesignerAccountCommand.java
@@ -1,6 +1,6 @@
 package com.peauty.designer.business.designer.dto;
 
-public record UpdateDesignerProfileCommand(
+public record UpdateDesignerAccountCommand(
         String name,
         String nickname,
         String phoneNumber,

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateDesignerAccountRequest.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateDesignerAccountRequest.java
@@ -2,9 +2,7 @@ package com.peauty.designer.business.designer.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record UpdateDesignerProfileResponse(
-        @Schema(description = "디자이너 ID", example = "1")
-        Long designerId,
+public record UpdateDesignerAccountRequest(
 
         @Schema(description = "디자이너 이름", example = "John Doe")
         String name,
@@ -15,20 +13,23 @@ public record UpdateDesignerProfileResponse(
         @Schema(description = "디자이너 전화번호", example = "01012345678")
         String phoneNumber,
 
+        @Schema(description = "디자이너 주소", example = "서울특별시 강남구 테헤란로 123")
+        String address,
+
         @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/profile.jpg")
         String profileImageUrl,
 
         @Schema(description = "디자이너 이메일", example = "johndoe@example.com")
         String email
 ) {
-    public static UpdateDesignerProfileResponse from(UpdateDesignerProfileResult result) {
-        return new UpdateDesignerProfileResponse(
-                result.designerId(),
-                result.name(),
-                result.nickname(),
-                result.phoneNumber(),
-                result.profileImageUrl(),
-                result.email()
+    public UpdateDesignerAccountCommand toCommand() {
+        return new UpdateDesignerAccountCommand(
+                this.name,
+                this.nickname,
+                this.phoneNumber,
+                this.address,
+                this.profileImageUrl,
+                this.email
         );
     }
 }

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateDesignerAccountResponse.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateDesignerAccountResponse.java
@@ -2,7 +2,9 @@ package com.peauty.designer.business.designer.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record UpdateDesignerProfileRequest(
+public record UpdateDesignerAccountResponse(
+        @Schema(description = "디자이너 ID", example = "1")
+        Long designerId,
 
         @Schema(description = "디자이너 이름", example = "John Doe")
         String name,
@@ -13,23 +15,20 @@ public record UpdateDesignerProfileRequest(
         @Schema(description = "디자이너 전화번호", example = "01012345678")
         String phoneNumber,
 
-        @Schema(description = "디자이너 주소", example = "서울특별시 강남구 테헤란로 123")
-        String address,
-
         @Schema(description = "프로필 이미지 URL", example = "https://example.com/images/profile.jpg")
         String profileImageUrl,
 
         @Schema(description = "디자이너 이메일", example = "johndoe@example.com")
         String email
 ) {
-    public UpdateDesignerProfileCommand toCommand() {
-        return new UpdateDesignerProfileCommand(
-                this.name,
-                this.nickname,
-                this.phoneNumber,
-                this.address,
-                this.profileImageUrl,
-                this.email
+    public static UpdateDesignerAccountResponse from(UpdateDesignerAccountResult result) {
+        return new UpdateDesignerAccountResponse(
+                result.designerId(),
+                result.name(),
+                result.nickname(),
+                result.phoneNumber(),
+                result.profileImageUrl(),
+                result.email()
         );
     }
 }

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateDesignerAccountResult.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateDesignerAccountResult.java
@@ -2,7 +2,7 @@ package com.peauty.designer.business.designer.dto;
 
 import com.peauty.domain.designer.Designer;
 
-public record UpdateDesignerProfileResult(
+public record UpdateDesignerAccountResult(
         Long designerId,
         String name,
         String nickname,
@@ -10,8 +10,8 @@ public record UpdateDesignerProfileResult(
         String profileImageUrl,
         String email
 ) {
-    public static UpdateDesignerProfileResult from(Designer designer){
-        return new UpdateDesignerProfileResult(
+    public static UpdateDesignerAccountResult from(Designer designer){
+        return new UpdateDesignerAccountResult(
                 designer.getDesignerId(),
                 designer.getName(),
                 designer.getNickname(),

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/DesignerController.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/DesignerController.java
@@ -25,18 +25,18 @@ public class DesignerController {
         return UploadProfileImageResponse.from(result);
     }
     // 디자이너 프로필 조회
-    @GetMapping("/{userId}/profile")
-    @Operation(summary = "디자이너 프로필 조회", description = "디자이너의 프로필 조회 API 진입점입니다.")
-    public GetDesignerProfileResponse getDesignerProfile(@PathVariable Long userId){
-        GetDesignerProfileResult result = designerService.getDesignerProfile(userId);
-        return GetDesignerProfileResponse.from(result);
+    @GetMapping("/{userId}/account")
+    @Operation(summary = "디자이너 계정 정보 조회", description = "디자이너의 계정 정보 조회 API 진입점입니다.")
+    public GetDesignerAccountResponse getDesignerAccount(@PathVariable Long userId){
+        GetDesignerAccountResult result = designerService.getDesignerAccount(userId);
+        return GetDesignerAccountResponse.from(result);
     }
     // 디자이너 프로필 수정
-    @PutMapping("/{userId}/profile")
-    @Operation(summary = "디자이너 프로필 수정", description = "디자이너의 프로필 수정 API 진입점입니다.")
-    public UpdateDesignerProfileResponse updateDesignerProfile(@PathVariable Long userId, @RequestBody UpdateDesignerProfileRequest request){
-        UpdateDesignerProfileResult result = designerService.updateDesignerProfile(userId, request.toCommand());
-        return UpdateDesignerProfileResponse.from(result);
+    @PutMapping("/{userId}/account")
+    @Operation(summary = "디자이너 계정 정보 수정", description = "디자이너의 계정 정보 수정 API 진입점입니다.")
+    public UpdateDesignerAccountResponse updateDesignerAccount(@PathVariable Long userId, @RequestBody UpdateDesignerAccountRequest request){
+        UpdateDesignerAccountResult result = designerService.updateDesignerAccount(userId, request.toCommand());
+        return UpdateDesignerAccountResponse.from(result);
     }
     // 닉네임 중복 체크
     @GetMapping("/check")

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/dto/GetDesignerAccountResponse.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/dto/GetDesignerAccountResponse.java
@@ -1,8 +1,8 @@
 package com.peauty.designer.presentation.controller.designer.dto;
 
-import com.peauty.designer.business.designer.dto.GetDesignerProfileResult;
+import com.peauty.designer.business.designer.dto.GetDesignerAccountResult;
 
-public record GetDesignerProfileResponse(
+public record GetDesignerAccountResponse(
         Long designerId,
         String name,
         String nickname,
@@ -11,8 +11,8 @@ public record GetDesignerProfileResponse(
         String phoneNumber
 ) {
 
-    public static GetDesignerProfileResponse from(GetDesignerProfileResult result) {
-        return new GetDesignerProfileResponse(
+    public static GetDesignerAccountResponse from(GetDesignerAccountResult result) {
+        return new GetDesignerAccountResponse(
                 result.designerId(),
                 result.name(),
                 result.nickname(),


### PR DESCRIPTION
## 📄 [PEAUTY-155] Designer profile -> account

Jira : [PEAUTY-155](https://multicampusuplus.atlassian.net/browse/PEAUTY-155?atlOrigin=eyJpIjoiNjRhM2E3ZWEzMzUxNGZlYzg2MTQ4YWM4MWI1NzlmZTUiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명

- 기존에는 디자이너 마이페이지에 보여줄 정보들을 묶어 디자이너 프로필이라고 했지만, 이젠 디자이너 계정 정보로 바뀝니다
- 이제 디자이너 프로필은 스크린샷처럼 이미지 Url, 닉네임, 가게 이름, 별점 평균, 별점 총 갯수, 경력, 대표뱃지, 가위를 묶은 컴포넌트입니다 스크린샷 참조
![스크린샷 2024-12-07 오후 2 30 42](https://github.com/user-attachments/assets/d4ffa587-189c-4cfe-9992-ffe2f06e770d)

![스크린샷 2024-12-07 오후 2 31 04](https://github.com/user-attachments/assets/067c3bf6-5e3b-4023-ae78-ed48586158b6)


<!-- Pull Request의 설명을 추가하세요. -->

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.1 MD
- Actual MD: 0.1 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
