### PR TITLE
[PEAUTY-156]  create designerProfile method in designerAdapter 

### DIFF
--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
@@ -11,12 +11,14 @@ import com.peauty.domain.designer.Workspace;
 import com.peauty.domain.exception.PeautyException;
 import com.peauty.domain.response.PeautyResponseCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -90,7 +92,7 @@ public class CustomerServiceImpl implements CustomerService {
         // 서울 강남구 대치동 -> 서울 강남구
         String[] addressParts = address.split(" ");
         if (addressParts.length < 2) {
-        // "" or "서울시"
+            // "" or "서울시"
             throw new PeautyException(PeautyResponseCode.INVALID_ADDRESS_FORMAT);
         }
         // 상위 주소만 딱 반환해버리기
@@ -109,7 +111,4 @@ public class CustomerServiceImpl implements CustomerService {
 
         return GetDesignerBadgesForCustomerResult.from(acquiredBadges, representativeBadges);
     }
-
-
-
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
@@ -59,7 +59,6 @@ public class CustomerServiceImpl implements CustomerService {
 
     @Override
     public void checkCustomerNicknameDuplicated(String nickname) {
-        designerPort.getDesignerProfileByDesignerId(1L);
         customerPort.checkCustomerNicknameDuplicated(nickname);
     }
 

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
@@ -59,6 +59,7 @@ public class CustomerServiceImpl implements CustomerService {
 
     @Override
     public void checkCustomerNicknameDuplicated(String nickname) {
+        designerPort.getDesignerProfileByDesignerId(1L);
         customerPort.checkCustomerNicknameDuplicated(nickname);
     }
 

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/designer/DesignerPort.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/designer/DesignerPort.java
@@ -1,6 +1,7 @@
 package com.peauty.customer.business.designer;
 
 import com.peauty.domain.designer.Badge;
+import com.peauty.domain.designer.Designer;
 
 import java.util.List;
 
@@ -11,4 +12,9 @@ public interface DesignerPort {
     List<Badge> getAllBadges(); // 전체 뱃지
 
     List<Badge> getAcquiredBadges(Long userId);
+
+    Designer getAllDesignerDataByDesignerId(Long userId);
+
+    Designer.Profile getDesignerProfileByDesignerId(Long designerId);
+
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspacePort.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspacePort.java
@@ -11,5 +11,5 @@ public interface WorkspacePort {
     List<Workspace> findAllWorkspaceByAddress(String address);
     Designer findDesignerById(Long designerId);
     Rating getRatingByWorkspaceId(Long workspaceId); // 추가된 메서드
-
+    Workspace getByDesignerId(Long designerId);
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/designer/DesignerAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/designer/DesignerAdapter.java
@@ -1,15 +1,23 @@
 package com.peauty.customer.implementaion.designer;
 
 import com.peauty.customer.business.designer.DesignerPort;
-import com.peauty.domain.designer.Badge;
+import com.peauty.customer.business.workspace.WorkspacePort;
+import com.peauty.domain.designer.*;
+import com.peauty.domain.exception.PeautyException;
+import com.peauty.domain.response.PeautyResponseCode;
+import com.peauty.persistence.designer.DesignerRepository;
 import com.peauty.persistence.designer.badge.BadgeEntity;
 import com.peauty.persistence.designer.badge.BadgeRepository;
 import com.peauty.persistence.designer.badge.DesignerBadgeEntity;
 import com.peauty.persistence.designer.badge.DesignerBadgeRepository;
+import com.peauty.persistence.designer.license.LicenseRepository;
+import com.peauty.persistence.designer.mapper.DesignerMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -18,8 +26,10 @@ public class DesignerAdapter implements DesignerPort {
 
     private final BadgeRepository badgeRepository;
     private final DesignerBadgeRepository designerBadgeRepository;
+    private final DesignerRepository designerRepository;
+    private final LicenseRepository licenseRepository;
+    private final WorkspacePort workspacePort;
 
-    // 대표뱃지 조회
     @Override
     public List<Badge> getRepresentativeBadges(Long userId) {
         List<Long> badgeIds = designerBadgeRepository.findRepresentativeBadgeIdsByDesignerId(userId);
@@ -61,7 +71,7 @@ public class DesignerAdapter implements DesignerPort {
 
         return badgeEntities.stream()
                 .map(badgeEntity -> {
-                    // 뱃지 ID가 일치하면서 대표뱃지가 True인 항목이 있는지 확인
+                    // 뱃지 ID가 3일치하면서 대표뱃지가 True인 항목이 있는지 확인
                     boolean isRepresentative = designerBadges.stream()
                             .anyMatch(designerBadgeEntity -> designerBadgeEntity.getBadgeId().equals(badgeEntity.getId()) && designerBadgeEntity.isRepresentativeBadge());
                     return Badge.builder()
@@ -76,6 +86,27 @@ public class DesignerAdapter implements DesignerPort {
                 .toList();
     }
 
+    @Override
+    public Designer getAllDesignerDataByDesignerId(Long userId) {
+        Designer designer = designerRepository.findById(userId)
+                .map(DesignerMapper::toDesignerDomain)
+                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_USER));
 
+        List<License> licenses = Optional.ofNullable(licenseRepository.findByDesignerId(userId))
+                .map(DesignerMapper::toLicenses)
+                .orElse(Collections.emptyList());
 
+        List<Badge> badges = getRepresentativeBadges(userId);
+
+        designer.updateLicenses(licenses);
+        designer.updateBadges(badges);
+        return designer;
+    }
+
+    @Override
+    public Designer.Profile getDesignerProfileByDesignerId(Long designerId) {
+        Designer designer = getAllDesignerDataByDesignerId(designerId);
+        Workspace workspace = workspacePort.getByDesignerId(designerId);
+        return designer.getProfile(workspace);
+    }
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/designer/DesignerAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/designer/DesignerAdapter.java
@@ -28,6 +28,7 @@ public class DesignerAdapter implements DesignerPort {
     private final DesignerBadgeRepository designerBadgeRepository;
     private final DesignerRepository designerRepository;
     private final LicenseRepository licenseRepository;
+    // TODO : 포트가 포트가 물고 있는 구조 -> 리팩토링 필수!
     private final WorkspacePort workspacePort;
 
     @Override

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/workspace/WorkspaceAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/workspace/WorkspaceAdapter.java
@@ -80,10 +80,11 @@ public Designer findDesignerById(Long designerId) {
 
     @Override
     public Workspace getByDesignerId(Long userId) {
+
         WorkspaceEntity workspaceEntity = Optional.ofNullable(workspaceRepository.findByDesignerId(userId))
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_USER));
-        RatingEntity ratingEntity = Optional.ofNullable(ratingRepository.findByWorkspaceId(workspaceEntity.getId()))
-                .orElse(null);
+        RatingEntity ratingEntity = ratingRepository.findByWorkspaceId(workspaceEntity.getId())
+                .orElseGet(null);
 
         Rating rating = WorkspaceMapper.toRatingDomain(ratingEntity);
         Workspace workspace = WorkspaceMapper.toDomain(workspaceEntity);

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/workspace/WorkspaceAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/workspace/WorkspaceAdapter.java
@@ -9,12 +9,16 @@ import com.peauty.persistence.designer.*;
 import com.peauty.persistence.designer.badge.BadgeEntity;
 import com.peauty.persistence.designer.badge.BadgeRepository;
 import com.peauty.persistence.designer.badge.DesignerBadgeRepository;
+import com.peauty.persistence.designer.mapper.WorkspaceMapper;
+import com.peauty.persistence.designer.rating.RatingEntity;
 import com.peauty.persistence.designer.rating.RatingRepository;
+import com.peauty.persistence.designer.workspace.WorkspaceEntity;
 import com.peauty.persistence.designer.workspace.WorkspaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -74,5 +78,16 @@ public Designer findDesignerById(Long designerId) {
                         .build());
     }
 
+    @Override
+    public Workspace getByDesignerId(Long userId) {
+        WorkspaceEntity workspaceEntity = Optional.ofNullable(workspaceRepository.findByDesignerId(userId))
+                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_USER));
+        RatingEntity ratingEntity = Optional.ofNullable(ratingRepository.findByWorkspaceId(workspaceEntity.getId()))
+                .orElse(null);
 
+        Rating rating = WorkspaceMapper.toRatingDomain(ratingEntity);
+        Workspace workspace = WorkspaceMapper.toDomain(workspaceEntity);
+        workspace.updateRating(rating);
+        return workspace;
+    }
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/workspace/WorkspaceAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/workspace/WorkspaceAdapter.java
@@ -81,10 +81,10 @@ public Designer findDesignerById(Long designerId) {
     @Override
     public Workspace getByDesignerId(Long userId) {
 
-        WorkspaceEntity workspaceEntity = Optional.ofNullable(workspaceRepository.findByDesignerId(userId))
+        WorkspaceEntity workspaceEntity = workspaceRepository.findByDesignerId(userId)
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_USER));
         RatingEntity ratingEntity = ratingRepository.findByWorkspaceId(workspaceEntity.getId())
-                .orElseGet(null);
+                .orElse(null);
 
         Rating rating = WorkspaceMapper.toRatingDomain(ratingEntity);
         Workspace workspace = WorkspaceMapper.toDomain(workspaceEntity);

--- a/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
@@ -14,8 +14,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -26,7 +24,7 @@ public class WorkspaceAdapter implements WorkspacePort {
     @Override
     public Workspace registerNew(Workspace workspace, Long designerId) {
         WorkspaceEntity workspaceEntityToSave = WorkspaceMapper.toEntity(workspace, designerId);
-        if(workspaceRepository.existsByDesignerId(workspaceEntityToSave.getDesignerId())){
+        if (workspaceRepository.existsByDesignerId(workspaceEntityToSave.getDesignerId())) {
             throw new PeautyException(PeautyResponseCode.ALREADY_EXIST_WORKSPACE);
         }
 
@@ -36,9 +34,9 @@ public class WorkspaceAdapter implements WorkspacePort {
 
     @Override
     public Workspace getByDesignerId(Long userId) {
-        WorkspaceEntity workspaceEntity = Optional.ofNullable(workspaceRepository.findByDesignerId(userId))
+        WorkspaceEntity workspaceEntity = workspaceRepository.findByDesignerId(userId)
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_USER));
-        RatingEntity ratingEntity =ratingRepository.findByWorkspaceId(workspaceEntity.getId())
+        RatingEntity ratingEntity = ratingRepository.findByWorkspaceId(workspaceEntity.getId())
                 .orElse(null);
 
         Rating rating = WorkspaceMapper.toRatingDomain(ratingEntity);

--- a/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
@@ -38,7 +38,7 @@ public class WorkspaceAdapter implements WorkspacePort {
     public Workspace getByDesignerId(Long userId) {
         WorkspaceEntity workspaceEntity = Optional.ofNullable(workspaceRepository.findByDesignerId(userId))
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_USER));
-        RatingEntity ratingEntity = Optional.ofNullable(ratingRepository.findByWorkspaceId(workspaceEntity.getId()))
+        RatingEntity ratingEntity =ratingRepository.findByWorkspaceId(workspaceEntity.getId())
                 .orElse(null);
 
         Rating rating = WorkspaceMapper.toRatingDomain(ratingEntity);
@@ -52,7 +52,7 @@ public class WorkspaceAdapter implements WorkspacePort {
         WorkspaceEntity workspaceEntityToUpdate = WorkspaceMapper.toEntity(workspace, userId);
         WorkspaceEntity updatedWorkspaceEntity = workspaceRepository.save(workspaceEntityToUpdate);
 
-        RatingEntity ratingEntity = Optional.ofNullable(ratingRepository.findByWorkspaceId(workspaceEntityToUpdate.getId()))
+        RatingEntity ratingEntity = ratingRepository.findByWorkspaceId(workspaceEntityToUpdate.getId())
                 .orElse(null);
 
         Rating rating = WorkspaceMapper.toRatingDomain(ratingEntity);

--- a/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
@@ -35,7 +35,7 @@ public class WorkspaceAdapter implements WorkspacePort {
     @Override
     public Workspace getByDesignerId(Long userId) {
         WorkspaceEntity workspaceEntity = workspaceRepository.findByDesignerId(userId)
-                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_USER));
+                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_EXIST_WORKSPACE));
         RatingEntity ratingEntity = ratingRepository.findByWorkspaceId(workspaceEntity.getId())
                 .orElse(null);
 

--- a/peauty-domain/src/main/java/com/peauty/domain/designer/Badge.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/designer/Badge.java
@@ -15,5 +15,4 @@ public class Badge {
     private String badgeImageUrl;
     private Boolean isRepresentativeBadge;
     private BadgeColor badgeColor;
-
 }

--- a/peauty-domain/src/main/java/com/peauty/domain/designer/Designer.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/designer/Designer.java
@@ -30,6 +30,33 @@ public class Designer {
     private List<License> licenses;
     private List<Badge> badges;
 
+    @Builder
+    public record Profile(
+            Long designerId,
+            String workspaceName,
+            String designerName,
+            Integer reviewCount,
+            Double reviewRating,
+            String profileImageUrl,
+            Integer yearOfExperience,
+            List<Badge> badges,
+            String address
+    ){
+    }
+
+    public Profile getProfile(Workspace workspace) {
+        return Profile.builder()
+                .designerName(this.name)
+                .badges(this.badges)
+                .profileImageUrl(this.profileImageUrl)
+                .yearOfExperience(this.yearOfExperience)
+                .reviewCount(workspace.getReviewCount())
+                .reviewRating(workspace.getReviewRating())
+                .workspaceName(workspace.getWorkspaceName())
+                .address(workspace.getAddress())
+                .build();
+    }
+
     public AuthInfo getAuthInfo() {
         return new AuthInfo(
                 designerId,

--- a/peauty-domain/src/main/java/com/peauty/domain/designer/Designer.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/designer/Designer.java
@@ -40,7 +40,8 @@ public class Designer {
             String profileImageUrl,
             Integer yearOfExperience,
             List<Badge> badges,
-            String address
+            String address,
+            Scissors scissors
     ){
     }
 
@@ -54,6 +55,7 @@ public class Designer {
                 .reviewRating(workspace.getReviewRating())
                 .workspaceName(workspace.getWorkspaceName())
                 .address(workspace.getAddress())
+                .scissors(workspace.getRating().getScissors())
                 .build();
     }
 

--- a/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/response/PeautyResponseCode.java
@@ -29,7 +29,7 @@ public enum PeautyResponseCode {
     WRONG_SEX("1208", "Invalid Puppy's Sex", "잘못된 애완견의 성별입니다."),
     WRONG_SIZE("1209", "Invalid Puppy's Size", "잘못된 애완견의 크기입니다."),
     NOT_FOUND_PUPPY("1210", "Puppy Not Found", "찾을 수 없는 반려견입니다."),
-    NOT_FOUND_WORKSPACE("1211", "Workspace Not Found", "가게가 존재하지 않습니다."),
+    NOT_EXIST_WORKSPACE("1211", "Workspace Not Found", "가게가 존재하지 않습니다."),
     INVALID_RATING("1211", "Invalid Rating", "잘못된 리뷰 평점입니다."),
     INVALID_GENERAL_CONTENT("1212", "Invalid GENERAL CONTENT", "잘못된 리뷰 선택 컨텐츠입니다."),
     INVALID_PAYMENT_OPTION("1213", "Invalid Payment Options", "잘못된 결제 방식입니다"),

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/mapper/DesignerMapper.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/mapper/DesignerMapper.java
@@ -12,6 +12,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.peauty.domain.designer.LicenseVerification.INCOMPLETE;
+
 public class DesignerMapper {
 
     private DesignerMapper() {
@@ -79,6 +81,7 @@ public class DesignerMapper {
                 .map(licenseEntity -> License.builder()
                         .licenseId(licenseEntity.getId())
                         .licenseImageUrl(licenseEntity.getLicenseImageUrl())
+                        .licenseVerification(INCOMPLETE)
                         .build())
                 .collect(Collectors.toList());
     }
@@ -92,6 +95,7 @@ public class DesignerMapper {
         return licenses.stream()
                 .map(license -> LicenseEntity.builder()
                         .licenseImageUrl(license.getLicenseImageUrl()) // License 이미지 URL 설정
+                        .licenseVerification(INCOMPLETE)
                         .designerId(designer.getDesignerId()) // Designer의 ID 설정
                         .build())
                 .collect(Collectors.toList());

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/mapper/DesignerMapper.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/mapper/DesignerMapper.java
@@ -81,7 +81,7 @@ public class DesignerMapper {
                 .map(licenseEntity -> License.builder()
                         .licenseId(licenseEntity.getId())
                         .licenseImageUrl(licenseEntity.getLicenseImageUrl())
-                        .licenseVerification(INCOMPLETE)
+                        .licenseVerification(licenseEntity.getLicenseVerification())
                         .build())
                 .collect(Collectors.toList());
     }

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/rating/RatingRepository.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/rating/RatingRepository.java
@@ -7,8 +7,6 @@ import java.util.Optional;
 
 @Repository
 public interface RatingRepository extends JpaRepository<RatingEntity, Long> {
-
         Optional<RatingEntity> findRatingByWorkspaceId(Long workspaceId);
-        RatingEntity findByWorkspaceId(Long id);
-
+        Optional<RatingEntity> findByWorkspaceId(Long id);
 }

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/workspace/WorkspaceRepository.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/workspace/WorkspaceRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 @Repository
 public interface
 WorkspaceRepository extends JpaRepository<WorkspaceEntity, Long> {
-    WorkspaceEntity findByDesignerId(Long userId);
+    Optional<WorkspaceEntity> findByDesignerId(Long userId);
 
     boolean existsByDesignerId(Long designerId);
 


### PR DESCRIPTION
## 📄 [PF-156] create designerProfile method in designerAdapter 

Jira : [PEAUTY-156](https://multicampusuplus.atlassian.net/browse/PEAUTY-156)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명

<!-- Pull Request의 설명을 추가하세요. -->
![image](https://github.com/user-attachments/assets/b02afd42-a94f-4d4a-b15c-f340b5ff2281)
- 사진의 컴포넌트에 해당하는 데이터를 가져올 수 있게하는 메서드를 designer adapter에 만들었습니다.
- designer api 모듈에서 사용하는 것을 customer에 동일하게 만들었습니다.
- designer안에 profile이라는 내부 레코드를 만들어서 다른 모듈에서도 사용할 수 있도록 만들었습니다.
    

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.4MD
- Actual MD: 0.4MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
