### PR TITLE
[PEAUTY-162] Impl get estimate designer profile that came to puppy

### DIFF
--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/CustomerBiddingService.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/CustomerBiddingService.java
@@ -1,10 +1,6 @@
 package com.peauty.customer.business.bidding;
 
-import com.peauty.customer.business.bidding.dto.AcceptEstimateResult;
-import com.peauty.customer.business.bidding.dto.GetEstimateAndProposalDetailsResult;
-import com.peauty.customer.business.bidding.dto.SendEstimateProposalCommand;
-import com.peauty.customer.business.bidding.dto.SendEstimateProposalResult;
-import org.springframework.web.bind.annotation.PathVariable;
+import com.peauty.customer.business.bidding.dto.*;
 
 public interface CustomerBiddingService {
 
@@ -26,5 +22,11 @@ public interface CustomerBiddingService {
             Long puppyId,
             Long processId,
             Long threadId
+    );
+
+    GetEstimateDesignerProfilesResult getEstimateDesignerProfiles(
+            Long userId,
+            Long puppyId,
+            Long processId
     );
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/CustomerBiddingServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/CustomerBiddingServiceImpl.java
@@ -78,6 +78,7 @@ public class CustomerBiddingServiceImpl implements CustomerBiddingService {
         );
     }
 
+    // TODO 쿼리 dsl 을 이용한 효율적인 쿼리 도입
     @Override
     public GetEstimateDesignerProfilesResult getEstimateDesignerProfiles(
             Long userId,

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/CustomerBiddingServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/CustomerBiddingServiceImpl.java
@@ -1,16 +1,16 @@
 package com.peauty.customer.business.bidding;
 
-import com.peauty.customer.business.bidding.dto.AcceptEstimateResult;
-import com.peauty.customer.business.bidding.dto.GetEstimateAndProposalDetailsResult;
-import com.peauty.customer.business.bidding.dto.SendEstimateProposalCommand;
-import com.peauty.customer.business.bidding.dto.SendEstimateProposalResult;
+import com.peauty.customer.business.bidding.dto.*;
 import com.peauty.customer.business.designer.DesignerPort;
 import com.peauty.customer.business.puppy.PuppyPort;
 import com.peauty.domain.bidding.*;
+import com.peauty.domain.designer.Designer;
 import com.peauty.domain.puppy.Puppy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -76,5 +76,20 @@ public class CustomerBiddingServiceImpl implements CustomerBiddingService {
                 estimateProposal,
                 estimate
         );
+    }
+
+    @Override
+    public GetEstimateDesignerProfilesResult getEstimateDesignerProfiles(
+            Long userId,
+            Long puppyId,
+            Long processId
+    ) {
+        BiddingProcess process = biddingProcessPort.getProcessByProcessIdAndPuppyId(processId, puppyId);
+        List<BiddingThread.Profile> threadProfiles = process.getThreads().stream()
+                .map(thread -> {
+                    Designer.Profile designerProfile = designerPort.getDesignerProfileByDesignerId(thread.getDesignerId().value());
+                    return thread.getProfile(designerProfile);
+                }).toList();
+        return GetEstimateDesignerProfilesResult.from(process, threadProfiles);
     }
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/dto/GetEstimateDesignerProfilesResult.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/dto/GetEstimateDesignerProfilesResult.java
@@ -1,0 +1,21 @@
+package com.peauty.customer.business.bidding.dto;
+
+import com.peauty.domain.bidding.BiddingProcess;
+import com.peauty.domain.bidding.BiddingThread;
+
+import java.util.List;
+
+public record GetEstimateDesignerProfilesResult(
+        BiddingProcess process,
+        List<BiddingThread.Profile> threadProfiles
+) {
+    public static GetEstimateDesignerProfilesResult from(
+            BiddingProcess process,
+            List<BiddingThread.Profile> threadProfiles
+    ) {
+        return new GetEstimateDesignerProfilesResult(
+                process,
+                threadProfiles
+        );
+    }
+}

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/designer/DesignerAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/designer/DesignerAdapter.java
@@ -108,6 +108,5 @@ public class DesignerAdapter implements DesignerPort {
         Designer designer = getAllDesignerDataByDesignerId(designerId);
         Workspace workspace = workspacePort.getByDesignerId(designerId);
         return designer.getProfile(workspace);
-
     }
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/bidding/CustomerBiddingController.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/bidding/CustomerBiddingController.java
@@ -3,11 +3,9 @@ package com.peauty.customer.presentation.controller.bidding;
 import com.peauty.customer.business.bidding.CustomerBiddingService;
 import com.peauty.customer.business.bidding.dto.AcceptEstimateResult;
 import com.peauty.customer.business.bidding.dto.GetEstimateAndProposalDetailsResult;
+import com.peauty.customer.business.bidding.dto.GetEstimateDesignerProfilesResult;
 import com.peauty.customer.business.bidding.dto.SendEstimateProposalResult;
-import com.peauty.customer.presentation.controller.bidding.dto.AcceptEstimateResponse;
-import com.peauty.customer.presentation.controller.bidding.dto.GetEstimateAndProposalDetailsResponse;
-import com.peauty.customer.presentation.controller.bidding.dto.SendEstimateProposalRequest;
-import com.peauty.customer.presentation.controller.bidding.dto.SendEstimateProposalResponse;
+import com.peauty.customer.presentation.controller.bidding.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -64,5 +62,20 @@ public class CustomerBiddingController {
                 threadId
         );
         return GetEstimateAndProposalDetailsResponse.from(result);
+    }
+
+    @GetMapping("/{userId}/puppies/{puppyId}/bidding/processes/{processId}/threads")
+    @Operation(summary = "견적서 응답 미용사 프로필 조회", description = "해당하는 견적요청서에 견적서를 보내준 미용사들의 프로필을 조회합니다.")
+    public GetEstimateDesignerProfilesResponse getEstimateDesignerProfiles(
+            @PathVariable Long userId,
+            @PathVariable Long puppyId,
+            @PathVariable Long processId
+    ) {
+        GetEstimateDesignerProfilesResult result = customerBiddingService.getEstimateDesignerProfiles(
+                userId,
+                puppyId,
+                processId
+        );
+        return GetEstimateDesignerProfilesResponse.from(result);
     }
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/bidding/dto/GetEstimateDesignerProfilesResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/bidding/dto/GetEstimateDesignerProfilesResponse.java
@@ -1,0 +1,21 @@
+package com.peauty.customer.presentation.controller.bidding.dto;
+
+import com.peauty.customer.business.bidding.dto.GetEstimateDesignerProfilesResult;
+import com.peauty.domain.bidding.BiddingThread;
+
+import java.util.List;
+
+public record GetEstimateDesignerProfilesResponse(
+        Long processId,
+        String processStatus,
+        List<BiddingThread.Profile> estimateDesigners
+) {
+
+    public static GetEstimateDesignerProfilesResponse from(GetEstimateDesignerProfilesResult result) {
+        return new GetEstimateDesignerProfilesResponse(
+                result.process().getSavedProcessId().value(),
+                result.process().getStatus().getDescription(),
+                result.threadProfiles()
+        );
+    }
+}

--- a/peauty-domain/src/main/java/com/peauty/domain/bidding/BiddingThread.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/bidding/BiddingThread.java
@@ -1,9 +1,11 @@
 package com.peauty.domain.bidding;
 
+import com.peauty.domain.designer.Designer;
 import com.peauty.domain.exception.PeautyException;
 import com.peauty.domain.response.PeautyResponseCode;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.Optional;
@@ -161,5 +163,23 @@ public class BiddingThread {
         public boolean isSameId(Long id) {
             return value.equals(id);
         }
+    }
+
+    public Profile getProfile(Designer.Profile designerProfile) {
+        return Profile.builder()
+                .threadId(id.value())
+                .step(step.getDescription())
+                .status(status.getDescription())
+                .designerProfile(designerProfile)
+                .build();
+    }
+
+    @Builder
+    public record Profile(
+            Long threadId,
+            String step,
+            String status,
+            Designer.Profile designerProfile
+    ) {
     }
 }


### PR DESCRIPTION
## 📄 [PEAUTY-162] Impl get estimate designer profile that came to puppy

Jira : [PEAUTY-162](https://multicampusuplus.atlassian.net/browse/PEAUTY-162?atlOrigin=eyJpIjoiMWNkMzdhZWRlMWVmNGM0MTljNTlmZTc3YTNkOWI5YjEiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명

- 내 강아지의 미용 프로세스의 스레드, 즉 내 강아지 미용 견적제안서를 보낸 미용사들 중 견적서 응답을 보낸 미용사들의 프로필과 함께 해당 스레드의 상태를 조회하는 API 를 만들었습니다
- 쿼리 dsl 이 시급해보이지만 일단 구현에 집중합니다

<img width="396" alt="스크린샷 2024-12-09 오후 5 43 38" src="https://github.com/user-attachments/assets/79f4bdc7-2c82-45ef-aa0b-19e13da95b60">


<!-- Pull Request의 설명을 추가하세요. -->

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.3 MD
- Actual MD: 0.3 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
