### PR TITLE
[PEAUTY-188] Impl get estimate proposal detail at designer

### DIFF
--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/DesignerBiddingServiceImpl.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/DesignerBiddingServiceImpl.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -57,7 +59,7 @@ public class DesignerBiddingServiceImpl implements DesignerBiddingService {
         BiddingProcess process = biddingProcessPort.getProcessByProcessId(processId);
         BiddingThread thread = process.getThread(new BiddingThread.ID(threadId));
         EstimateProposal estimateProposal = estimateProposalPort.getProposalByProcessId(process.getSavedProcessId().value());
-        Estimate estimate = estimatePort.getEstimateByThreadId(thread.getSavedThreadId().value());
+        Optional<Estimate> estimate = estimatePort.findEstimateByThreadId(thread.getSavedThreadId().value());
         Puppy puppy = puppyPort.getPuppyByPuppyId(process.getPuppyId().value());
         // TODO 이 스레드가 본인의 스레드인지 검증
         return GetEstimateAndProposalDetailsResult.from(

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/EstimatePort.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/EstimatePort.java
@@ -2,9 +2,12 @@ package com.peauty.designer.business.bidding;
 
 import com.peauty.domain.bidding.Estimate;
 
+import java.util.Optional;
+
 public interface EstimatePort {
 
     Estimate save(Estimate estimate);
     Estimate getEstimateByEstimateId(Long estimateId);
     Estimate getEstimateByThreadId(Long threadId);
+    Optional<Estimate> findEstimateByThreadId(Long threadId);
 }

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/dto/GetEstimateAndProposalDetailsResult.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/dto/GetEstimateAndProposalDetailsResult.java
@@ -6,12 +6,14 @@ import com.peauty.domain.bidding.Estimate;
 import com.peauty.domain.bidding.EstimateProposal;
 import com.peauty.domain.puppy.Puppy;
 
+import java.util.Optional;
+
 public record GetEstimateAndProposalDetailsResult(
         BiddingProcess process,
         BiddingThread thread,
         Puppy puppy,
         EstimateProposal estimateProposal,
-        Estimate estimate
+        Optional<Estimate> estimate
 ) {
 
     public static GetEstimateAndProposalDetailsResult from(
@@ -19,7 +21,7 @@ public record GetEstimateAndProposalDetailsResult(
             BiddingThread thread,
             Puppy puppy,
             EstimateProposal estimateProposal,
-            Estimate estimate
+            Optional<Estimate> estimate
     ) {
         return new GetEstimateAndProposalDetailsResult(
                 process,

--- a/peauty-designer-api/src/main/java/com/peauty/designer/implementation/bidding/EstimateAdapter.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/implementation/bidding/EstimateAdapter.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -44,4 +45,15 @@ public class EstimateAdapter implements EstimatePort {
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_FOUND_ESTIMATE));
         List<EstimateImageEntity> foundImageEntities = estimateImageRepository.findByEstimateId(foundEstimateEntity.getId());
         return EstimateMapper.toEstimateDomain(foundEstimateEntity, foundImageEntities);
-    }}
+    }
+
+    @Override
+    public Optional<Estimate> findEstimateByThreadId(Long threadId) {
+        Optional<EstimateEntity> foundEstimateEntity = estimateRepository.findByBiddingThreadId(threadId);
+
+        return foundEstimateEntity.map(estimateEntity -> {
+            List<EstimateImageEntity> foundImageEntities = estimateImageRepository.findByEstimateId(estimateEntity.getId());
+            return EstimateMapper.toEstimateDomain(estimateEntity, foundImageEntities);
+        });
+    }
+}

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/bidding/dto/GetEstimateAndProposalDetailsResponse.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/bidding/dto/GetEstimateAndProposalDetailsResponse.java
@@ -25,7 +25,7 @@ public record GetEstimateAndProposalDetailsResponse(
                 result.thread().getStatus().getDescription(),
                 result.puppy().getProfile(),
                 result.estimateProposal().getProfile(),
-                result.estimate().getProfile()
+                result.estimate().map(Estimate::getProfile).orElse(null)
         );
     }
 }


### PR DESCRIPTION
## 📄 [PEAUTY-188] Impl get estimate proposal detail at designer

Jira : [PEAUTY-188](https://multicampusuplus.atlassian.net/browse/PEAUTY-188?atlOrigin=eyJpIjoiMjc3NTAxOGUxMzk4NDYzZThmN2E1OTFkMWVkNzBlMDciLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명

- 디자이너 입장에서 본인에게 온 견적 제안서의 디테일을 조회하는 기능을 구현하고자 했습니다
- 근데 알고보니 getEstimateAndProposalDetails 을 쓰면 될 것 같았습니다
- Estimate 가 없는 상황이 있을 수 있으니 Optional 로 바꿔줬습니다

<!-- Pull Request의 설명을 추가하세요. -->

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.2 MD
- Actual MD: 0.2 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
