### PR TITLE
[PEAUTY-222] Move Workspace Detail API from Designer Module to Customer Module

### DIFF
--- a/peauty-auth/src/main/java/com/peauty/auth/config/SecurityConfig.java
+++ b/peauty-auth/src/main/java/com/peauty/auth/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                         "/webjars/**",
                         "/h2-console/**",
                         "/actuator/**",
-                        "/static/"
+                        "/static/**"
                 ).permitAll()
                 .requestMatchers(
                         "/sign-out"

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerPort.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerPort.java
@@ -16,5 +16,4 @@ public interface CustomerPort {
     Customer getCustomerById(Long customerId);
 
 
-
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerService.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerService.java
@@ -1,7 +1,7 @@
 package com.peauty.customer.business.customer;
 
 import com.peauty.customer.business.customer.dto.*;
-import com.peauty.customer.business.workspace.dto.GetDesignerWorkspaceResult;
+import com.peauty.customer.business.workspace.dto.GetAroundWorkspacesResult;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface CustomerService {
@@ -9,6 +9,5 @@ public interface CustomerService {
     GetCustomerProfileResult getCustomerProfile(Long customerId);
     UpdateCustomerProfileResult updateCustomerProfile(Long customerId, UpdateCustomerProfileCommand command);
     void checkCustomerNicknameDuplicated(String nickname);
-    GetAroundWorkspacesResult getAroundWorkspaces(Long customerId);
     GetDesignerBadgesForCustomerResult getDesignerBadgesByCustomer(Long designerId);
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerService.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerService.java
@@ -1,6 +1,7 @@
 package com.peauty.customer.business.customer;
 
 import com.peauty.customer.business.customer.dto.*;
+import com.peauty.customer.business.workspace.dto.GetDesignerWorkspaceResult;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface CustomerService {

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
@@ -2,15 +2,9 @@ package com.peauty.customer.business.customer;
 
 import com.peauty.customer.business.customer.dto.*;
 import com.peauty.customer.business.designer.DesignerPort;
-import com.peauty.customer.business.workspace.dto.GetDesignerWorkspaceResult;
 import com.peauty.customer.business.internal.InternalPort;
-import com.peauty.customer.business.workspace.WorkspacePort;
 import com.peauty.domain.customer.Customer;
 import com.peauty.domain.designer.Badge;
-import com.peauty.domain.designer.Designer;
-import com.peauty.domain.designer.Workspace;
-import com.peauty.domain.exception.PeautyException;
-import com.peauty.domain.response.PeautyResponseCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,7 +21,6 @@ public class CustomerServiceImpl implements CustomerService {
 
     private final CustomerPort customerPort;
     private final InternalPort internalPort;
-    private final WorkspacePort workspacePort;
     private final DesignerPort designerPort;
 
     @Override
@@ -65,50 +58,6 @@ public class CustomerServiceImpl implements CustomerService {
     }
 
     @Override
-    public GetAroundWorkspacesResult getAroundWorkspaces(Long customerId) {
-        // 고객 정보 조회
-        Customer customer = customerPort.getCustomerById(customerId);
-        // OO시 OO구 까지 추출
-        String customerBaseAddress = extractBaseAddress(customer.getAddress());
-        // 고객의 상위주소와 맞는 미용실 전체 조회
-        List<Workspace> workspaces = workspacePort.findAllWorkspaceByAddress(customerBaseAddress);
-        // 각 미용실에 해당하는 디자이너 정보를 매핑
-        List<GetAroundWorkspaceResult> workspaceResults = workspaces.stream()
-                .map(workspace -> {
-                    // 미용실을 소유한 디자이너 조회
-                    Designer designer = workspacePort.findDesignerById(workspace.getDesignerId());
-                    // 대표 뱃지 정보 가져오기 (이름과 색상, 타입 포함)
-                    List<GetAroundWorkspaceResult.Badge> representativeBadges = designerPort.getRepresentativeBadges(designer.getDesignerId())
-                            .stream()
-                            .map(badge -> new GetAroundWorkspaceResult.Badge(
-                                    badge.getBadgeId(),
-                                    badge.getBadgeName(),
-                                    badge.getBadgeContent(),
-                                    badge.getBadgeImageUrl(),
-                                    badge.getBadgeColor(),
-                                    badge.getBadgeType()
-                            ))
-                            .toList();
-                    return GetAroundWorkspaceResult.from(workspace, designer, representativeBadges);
-                })
-                .toList();
-
-        return GetAroundWorkspacesResult.from(customer, workspaceResults);
-    }
-
-    private String extractBaseAddress(String address) {
-        // 어절(띄어쓰기)로 파싱.
-        // 서울 강남구 대치동 -> 서울 강남구
-        String[] addressParts = address.split(" ");
-        if (addressParts.length < 2) {
-            // "" or "서울시"
-            throw new PeautyException(PeautyResponseCode.INVALID_ADDRESS_FORMAT);
-        }
-        // 상위 주소만 딱 반환해버리기
-        return addressParts[0] + " " + addressParts[1];
-    }
-
-    @Override
     public GetDesignerBadgesForCustomerResult getDesignerBadgesByCustomer(Long designerId) {
         // 디자이너가 획득한 뱃지 가져오기
         List<Badge> acquiredBadges = designerPort.getAcquiredBadges(designerId);
@@ -120,7 +69,4 @@ public class CustomerServiceImpl implements CustomerService {
 
         return GetDesignerBadgesForCustomerResult.from(acquiredBadges, representativeBadges);
     }
-
-
-
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/customer/CustomerServiceImpl.java
@@ -2,6 +2,7 @@ package com.peauty.customer.business.customer;
 
 import com.peauty.customer.business.customer.dto.*;
 import com.peauty.customer.business.designer.DesignerPort;
+import com.peauty.customer.business.workspace.dto.GetDesignerWorkspaceResult;
 import com.peauty.customer.business.internal.InternalPort;
 import com.peauty.customer.business.workspace.WorkspacePort;
 import com.peauty.domain.customer.Customer;
@@ -119,4 +120,7 @@ public class CustomerServiceImpl implements CustomerService {
 
         return GetDesignerBadgesForCustomerResult.from(acquiredBadges, representativeBadges);
     }
+
+
+
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspaceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspaceImpl.java
@@ -1,24 +1,77 @@
 package com.peauty.customer.business.workspace;
 
+import com.peauty.customer.business.customer.CustomerPort;
+import com.peauty.customer.business.workspace.dto.GetAroundWorkspaceResult;
+import com.peauty.customer.business.workspace.dto.GetAroundWorkspacesResult;
 import com.peauty.customer.business.designer.DesignerPort;
 import com.peauty.customer.business.workspace.dto.GetDesignerWorkspaceResult;
+import com.peauty.domain.customer.Customer;
 import com.peauty.domain.designer.Designer;
 import com.peauty.domain.designer.Workspace;
+import com.peauty.domain.exception.PeautyException;
+import com.peauty.domain.response.PeautyResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class WorkspaceImpl implements WorkspaceService {
     private final DesignerPort designerPort;
     private final WorkspacePort workspacePort;
+    private final CustomerPort customerPort;
 
     @Override
-    public GetDesignerWorkspaceResult getWorkspaceDetail(Long designerId) {
+    public GetDesignerWorkspaceResult getWorkspaceDetails(Long designerId) {
         Designer designer = designerPort.getAllDesignerDataByDesignerId(designerId);
         Workspace workspace = workspacePort.getByDesignerId(designerId);
 
         designer.updateBadges(designerPort.getRepresentativeBadges(designerId));
         return GetDesignerWorkspaceResult.from(designer, workspace);
+    }
+
+    @Override
+    public GetAroundWorkspacesResult getAroundWorkspaces(Long customerId) {
+        // 고객 정보 조회
+        Customer customer = customerPort.getCustomerById(customerId);
+        // OO시 OO구 까지 추출
+        String customerBaseAddress = extractBaseAddress(customer.getAddress());
+        // 고객의 상위주소와 맞는 미용실 전체 조회
+        List<Workspace> workspaces = workspacePort.findAllWorkspaceByAddress(customerBaseAddress);
+        // 각 미용실에 해당하는 디자이너 정보를 매핑
+        List<GetAroundWorkspaceResult> workspaceResults = workspaces.stream()
+                .map(workspace -> {
+                    // 미용실을 소유한 디자이너 조회
+                    Designer designer = workspacePort.findDesignerById(workspace.getDesignerId());
+                    // 대표 뱃지 정보 가져오기 (이름과 색상, 타입 포함)
+                    List<GetAroundWorkspaceResult.Badge> representativeBadges = designerPort.getRepresentativeBadges(designer.getDesignerId())
+                            .stream()
+                            .map(badge -> new GetAroundWorkspaceResult.Badge(
+                                    badge.getBadgeId(),
+                                    badge.getBadgeName(),
+                                    badge.getBadgeContent(),
+                                    badge.getBadgeImageUrl(),
+                                    badge.getBadgeColor(),
+                                    badge.getBadgeType()
+                            ))
+                            .toList();
+                    return GetAroundWorkspaceResult.from(workspace, designer, representativeBadges);
+                })
+                .toList();
+
+        return GetAroundWorkspacesResult.from(customer, workspaceResults);
+    }
+
+    private String extractBaseAddress(String address) {
+        // 어절(띄어쓰기)로 파싱.
+        // 서울 강남구 대치동 -> 서울 강남구
+        String[] addressParts = address.split(" ");
+        if (addressParts.length < 2) {
+            // "" or "서울시"
+            throw new PeautyException(PeautyResponseCode.INVALID_ADDRESS_FORMAT);
+        }
+        // 상위 주소만 딱 반환해버리기
+        return addressParts[0] + " " + addressParts[1];
     }
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspaceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspaceImpl.java
@@ -1,0 +1,24 @@
+package com.peauty.customer.business.workspace;
+
+import com.peauty.customer.business.designer.DesignerPort;
+import com.peauty.customer.business.workspace.dto.GetDesignerWorkspaceResult;
+import com.peauty.domain.designer.Designer;
+import com.peauty.domain.designer.Workspace;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WorkspaceImpl implements WorkspaceService {
+    private final DesignerPort designerPort;
+    private final WorkspacePort workspacePort;
+
+    @Override
+    public GetDesignerWorkspaceResult getWorkspaceDetail(Long designerId) {
+        Designer designer = designerPort.getAllDesignerDataByDesignerId(designerId);
+        Workspace workspace = workspacePort.getByDesignerId(designerId);
+
+        designer.updateBadges(designerPort.getRepresentativeBadges(designerId));
+        return GetDesignerWorkspaceResult.from(designer, workspace);
+    }
+}

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspaceService.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspaceService.java
@@ -1,7 +1,10 @@
 package com.peauty.customer.business.workspace;
 
+import com.peauty.customer.business.workspace.dto.GetAroundWorkspacesResult;
 import com.peauty.customer.business.workspace.dto.GetDesignerWorkspaceResult;
 
 public interface WorkspaceService {
-    GetDesignerWorkspaceResult getWorkspaceDetail(Long workspaceId);
+    GetDesignerWorkspaceResult getWorkspaceDetails(Long designerId);
+
+    GetAroundWorkspacesResult getAroundWorkspaces(Long userId);
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspaceService.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/WorkspaceService.java
@@ -1,0 +1,7 @@
+package com.peauty.customer.business.workspace;
+
+import com.peauty.customer.business.workspace.dto.GetDesignerWorkspaceResult;
+
+public interface WorkspaceService {
+    GetDesignerWorkspaceResult getWorkspaceDetail(Long workspaceId);
+}

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/dto/GetAroundWorkspaceResult.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/dto/GetAroundWorkspaceResult.java
@@ -1,4 +1,4 @@
-package com.peauty.customer.business.customer.dto;
+package com.peauty.customer.business.workspace.dto;
 
 import com.peauty.domain.designer.*;
 

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/dto/GetAroundWorkspacesResult.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/dto/GetAroundWorkspacesResult.java
@@ -1,4 +1,4 @@
-package com.peauty.customer.business.customer.dto;
+package com.peauty.customer.business.workspace.dto;
 
 import com.peauty.domain.customer.Customer;
 

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/dto/GetDesignerWorkspaceResult.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/workspace/dto/GetDesignerWorkspaceResult.java
@@ -1,0 +1,64 @@
+package com.peauty.customer.business.workspace.dto;
+
+import com.peauty.domain.designer.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record GetDesignerWorkspaceResult(
+        Long designerId,
+        Long workspaceId,
+        String bannerImageUrl,
+        String workspaceName,
+        Double reviewRating,
+        Integer reviewsCount,
+        Scissors scissors,
+        String introduceTitle,
+        String introduce,
+        String noticeTitle,
+        String notice,
+        String address,
+        String addressDetail,
+        String phoneNumber,
+        Integer yearOfExperience,
+        String openHours,
+        String closeHours,
+        String openDays,
+        String directionGuide,
+        List<String> licenses,
+        List<String> paymentOptions,
+        List<String> representativeBadgeNames
+) {
+    public static GetDesignerWorkspaceResult from(Designer designer, Workspace workspace) {
+        List<String> licenses = designer.getLicenses().stream()
+                .map(License::getLicenseImageUrl)
+                .toList();
+
+        return new GetDesignerWorkspaceResult(
+                designer.getDesignerId(),
+                workspace.getWorkspaceId(),
+                workspace.getBannerImageUrl(),
+                workspace.getWorkspaceName(),
+                workspace.getReviewRating(),
+                workspace.getReviewCount(),
+                workspace.getRating().getScissors(),
+                workspace.getIntroduceTitle(),
+                workspace.getIntroduce(),
+                workspace.getNoticeTitle(),
+                workspace.getNotice(),
+                workspace.getAddress(),
+                workspace.getAddressDetail(),
+                designer.getPhoneNumber(),
+                designer.getYearOfExperience(),
+                workspace.getOpenHours(),
+                workspace.getCloseHours(),
+                workspace.getOpenDays(),
+                workspace.getDirectionGuide(),
+                licenses,
+                workspace.getPaymentOptions().stream().map(PaymentOption::getOptionName).toList(),
+                designer.getBadges().stream()
+                        .map(Badge::getBadgeName)
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/CustomerController.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/CustomerController.java
@@ -3,6 +3,7 @@ package com.peauty.customer.presentation.controller.customer;
 import com.peauty.customer.business.customer.CustomerService;
 import com.peauty.customer.business.customer.dto.*;
 import com.peauty.customer.business.workspace.WorkspaceService;
+import com.peauty.customer.business.workspace.dto.GetAroundWorkspacesResult;
 import com.peauty.customer.business.workspace.dto.GetDesignerWorkspaceResult;
 import com.peauty.customer.business.review.ReviewService;
 import com.peauty.customer.presentation.controller.customer.dto.*;
@@ -57,7 +58,7 @@ public class CustomerController {
     @GetMapping("/users/{userId}/serach")
     @Operation(summary = "주변 디자이너 매장 조회", description = "고객 주소와 같은 디자이너의 매장을 조회하는 API 진입점입니다.")
     public GetAroundWorkspacesResponse getAroundWorkspaces(@PathVariable Long userId) {
-        GetAroundWorkspacesResult result = customerService.getAroundWorkspaces(userId);
+        GetAroundWorkspacesResult result = workspaceService.getAroundWorkspaces(userId);
         return GetAroundWorkspacesResponse.from(result);
     }
 
@@ -71,7 +72,7 @@ public class CustomerController {
     @GetMapping(value = "/{userId}/shop")
     @Operation(summary = "디자이너 워크 스페이스 조회", description = "디자이너 워크 스페이스 조회 API 진입점입니다.")
     public GetDesignerWorkspaceResponse getDesignerWorkspace(@PathVariable Long userId) {
-        GetDesignerWorkspaceResult result = workspaceService.getWorkspaceDetail(userId);
+        GetDesignerWorkspaceResult result = workspaceService.getWorkspaceDetails(userId);
         return GetDesignerWorkspaceResponse.from(result);
     }
 
@@ -90,5 +91,4 @@ public class CustomerController {
                 request.toCommand());
         return RegisterReviewResponse.from(result);
     }*/
-
 }

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/CustomerController.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/CustomerController.java
@@ -2,11 +2,10 @@ package com.peauty.customer.presentation.controller.customer;
 
 import com.peauty.customer.business.customer.CustomerService;
 import com.peauty.customer.business.customer.dto.*;
+import com.peauty.customer.business.workspace.WorkspaceService;
+import com.peauty.customer.business.workspace.dto.GetDesignerWorkspaceResult;
 import com.peauty.customer.business.review.ReviewService;
-import com.peauty.customer.business.review.dto.RegisterReviewResult;
 import com.peauty.customer.presentation.controller.customer.dto.*;
-import com.peauty.customer.presentation.controller.review.dto.RegisterReviewRequest;
-import com.peauty.customer.presentation.controller.review.dto.RegisterReviewResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +21,7 @@ public class CustomerController {
 
     private final CustomerService customerService;
     private final ReviewService reviewService;
+    private final WorkspaceService workspaceService;
 
     @PostMapping(value = "/users/{userId}/profile/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "고객 프로필 이미지 업로드", description = "고객의 프로필 이미지 업로드 API 진입점입니다.")
@@ -66,6 +66,13 @@ public class CustomerController {
     public GetDesignerBadgesForCustomerResponse getDesignerBadgesForCustomer(@PathVariable Long designerId) {
         GetDesignerBadgesForCustomerResult result = customerService.getDesignerBadgesByCustomer(designerId);
         return GetDesignerBadgesForCustomerResponse.from(result);
+    }
+
+    @GetMapping(value = "/{userId}/shop")
+    @Operation(summary = "디자이너 워크 스페이스 조회", description = "디자이너 워크 스페이스 조회 API 진입점입니다.")
+    public GetDesignerWorkspaceResponse getDesignerWorkspace(@PathVariable Long userId) {
+        GetDesignerWorkspaceResult result = workspaceService.getWorkspaceDetail(userId);
+        return GetDesignerWorkspaceResponse.from(result);
     }
 
 /*    @PostMapping("/users/{userId}/puppies/{puppyId}/bidding/processes/{processId}/threads/{threadId}/reviews")

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetAroundWorkspaceResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetAroundWorkspaceResponse.java
@@ -1,9 +1,8 @@
 package com.peauty.customer.presentation.controller.customer.dto;
 
-import com.peauty.customer.business.customer.dto.GetAroundWorkspaceResult;
+import com.peauty.customer.business.workspace.dto.GetAroundWorkspaceResult;
 import com.peauty.domain.designer.BadgeColor;
 import com.peauty.domain.designer.BadgeType;
-import com.peauty.domain.designer.Scissors;
 
 import java.util.List;
 

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetAroundWorkspacesResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetAroundWorkspacesResponse.java
@@ -1,6 +1,6 @@
 package com.peauty.customer.presentation.controller.customer.dto;
 
-import com.peauty.customer.business.customer.dto.GetAroundWorkspacesResult;
+import com.peauty.customer.business.workspace.dto.GetAroundWorkspacesResult;
 
 import java.util.List;
 

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetDesignerWorkspaceResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/dto/GetDesignerWorkspaceResponse.java
@@ -1,0 +1,83 @@
+package com.peauty.customer.presentation.controller.customer.dto;
+
+import com.peauty.customer.business.workspace.dto.*;
+import com.peauty.domain.designer.Scissors;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record GetDesignerWorkspaceResponse(
+        @Schema(description = "디자이너 ID (PK)", example = "1")
+        Long designerId,
+        @Schema(description = "워크 스페이스 ID (PK)", example = "2")
+        Long workspaceId,
+        @Schema(description = "배너 이미지 URL", example = "이미지 url")
+        String bannerImageUrl,
+        @Schema(description = "가게 이름", example = "호키포키")
+        String workspaceName,
+        @Schema(description = "평점", example = "4.5")
+        Double reviewRating,
+        @Schema(description = "리뷰 수", example = "5")
+        Integer reviewsCount,
+        @Schema(description = "가위 종류", example = "GOLD")
+        Scissors scissors,
+        @Schema(description = "소개 제목", example = "호키포키에 오신 여러분들 환영합니다!")
+        String introduceTitle,
+        @Schema(description = "소개", example = "안녕하세요. 말티즈 및 푸들 모발 케어 호키포키입니다.")
+        String introduce,
+        @Schema(description = "공지사항", example = "5주년 특별 공지 사항")
+        String noticeTitle,
+        @Schema(description = "공지사항", example = "저희 호키포키에서 5주년 이벤트로 예약 자에 한에서 반려견 피부 보습 케어..")
+        String notice,
+        @Schema(description = "주소", example = "성남시 위례구 사미동")
+        String address,
+        @Schema(description = "상세 주소", example = "대성 베르힐 1401호")
+        String addressDetail,
+        @Schema(description = "전화번호", example = "01011112222")
+        String phoneNumber,
+        @Schema(description = "경력 연수", example = "5")
+        Integer yearOfExperience,
+        @Schema(description = "오픈 시간", example = "10:00")
+        String openHours,
+        @Schema(description = "마감 시간", example = "20:00")
+        String closeHours,
+        @Schema(description = "영업일", example = "주말휴무")
+        String openDay,
+        @Schema(description = "매장까지의 거리 정보(시간)", example = "위례역 도보 3분 거리")
+        String directionGuide,
+        @Schema(description = "자격증 이미지 URL들", example = "[\"자격증 이미지 url1\", \"자격증 이미지 url2\"]")
+        List<String> licenses,
+        @Schema(description = "결제 방식", example = "[\"계좌 이체\", \"현금 결제\", \"카드 결제\"]")
+        List<String> paymentOptions,
+        @Schema(description = "대표 배지 이름들", example = "[\"사업자 등록 인증\", \"말티즈 전문가\"]")
+        List<String> representativeBadgeNames
+
+
+) {
+    public static GetDesignerWorkspaceResponse from(GetDesignerWorkspaceResult result) {
+        return new GetDesignerWorkspaceResponse(
+                result.designerId(),
+                result.workspaceId(),
+                result.bannerImageUrl(),
+                result.workspaceName(),
+                result.reviewRating(),
+                result.reviewsCount(),
+                result.scissors(),
+                result.introduceTitle(),
+                result.introduce(),
+                result.noticeTitle(),
+                result.notice(),
+                result.address(),
+                result.addressDetail(),
+                result.phoneNumber(),
+                result.yearOfExperience(),
+                result.openHours(),
+                result.closeHours(),
+                result.openDays(),
+                result.directionGuide(),
+                result.licenses(),
+                result.paymentOptions(),
+                result.representativeBadgeNames()
+                );
+    }
+}

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/DesignerController.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/designer/DesignerController.java
@@ -54,12 +54,13 @@ public class DesignerController {
         return CreateDesignerWorkspaceResponse.from(result);
     }
 
-    @GetMapping(value = "/{userId}/shop")
-    @Operation(summary = "디자이너 워크 스페이스 조회", description = "디자이너 워크 스페이스 조회 API 진입점입니다.")
-    public GetDesignerWorkspaceResponse getDesignerWorkspace(@PathVariable Long userId) {
-        GetDesignerWorkspaceResult result = designerService.getDesignerWorkspace(userId);
-        return GetDesignerWorkspaceResponse.from(result);
-    }
+//    Designer모듈에서 Customer 모듈로 이동했습니다. 혹시 몰라서 컨트롤러만 막아 둡니다.
+//    @GetMapping(value = "/{userId}/shop")
+//    @Operation(summary = "디자이너 워크 스페이스 조회", description = "디자이너 워크 스페이스 조회 API 진입점입니다.")
+//    public GetDesignerWorkspaceResponse getDesignerWorkspace(@PathVariable Long userId) {
+//        GetDesignerWorkspaceResult result = designerService.getDesignerWorkspace(userId);
+//        return GetDesignerWorkspaceResponse.from(result);
+//    }
 
     @PutMapping(value = "/{userId}/shop")
     @Operation(summary = "디자이너 워크 스페이스 수정", description = "디자이너 워크 스페이스 수정 API 진입점입니다.")


### PR DESCRIPTION
## 📄 [PF-222]  Move Workspace Detail API from Designer Module to Customer Module

Jira : [PEAUTY-222](https://multicampusuplus.atlassian.net/browse/PEAUTY-222?atlOrigin=eyJpIjoiNzg5Y2NlYTRmMDhhNDY3ZGI4Njc5MWNiMzk0ZmRkNGUiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명
- [x] 버그 수정 설명
- [x] 문서 수정 설명

<!-- Pull Request의 설명을 추가하세요. -->
- 워크스페이스 세부사항 조회 API를 사용하는 사용자는 designer가 아니라 customer이기 때문에, designer 모듈에서 customer 모듈로 이동했습니다.
- 내 주변 워크스페이스 찾기 API 또한 customer에 패키지에 있어서 workspace 패키지로 관련 클래스와 메서드들을 이동했습니다.

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.1MD
- Actual MD: 0.1MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
