### PR TITLE
[PEAUTY-213] Impl image generator and dalle client

### DIFF
--- a/peauty-addy/build.gradle
+++ b/peauty-addy/build.gradle
@@ -7,4 +7,8 @@ jar {
 }
 
 dependencies {
+	implementation(project(':peauty-domain'))
+	implementation(project(':peauty-aws'))
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.2'
 }

--- a/peauty-addy/src/main/java/com/peauty/addy/AddyConfig.java
+++ b/peauty-addy/src/main/java/com/peauty/addy/AddyConfig.java
@@ -1,4 +1,0 @@
-package com.peauty.addy;
-
-public class AddyConfig {
-}

--- a/peauty-addy/src/main/java/com/peauty/addy/FeignConfig.java
+++ b/peauty-addy/src/main/java/com/peauty/addy/FeignConfig.java
@@ -1,0 +1,13 @@
+package com.peauty.addy;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients
+public class FeignConfig {
+
+    @Value("${openai.api.key}")
+    String openapiKey;
+}

--- a/peauty-addy/src/main/java/com/peauty/addy/dalle/DalleClient.java
+++ b/peauty-addy/src/main/java/com/peauty/addy/dalle/DalleClient.java
@@ -1,0 +1,22 @@
+package com.peauty.addy.dalle;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+@FeignClient(name = "dalle edit image", url = "https://api.openai.com/v1")
+public interface DalleClient {
+    @PostMapping(value = "/images/edits", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    DalleEditImageResponse editImage(
+            @RequestPart("image") MultipartFile image,
+            @RequestPart("mask") MultipartFile mask,
+            @RequestPart("model") String model,
+            @RequestPart("prompt") String prompt,
+            @RequestPart("n") Integer n,
+            @RequestPart("size") String size,
+            @RequestHeader("Authorization") String bearerToken
+    );
+}

--- a/peauty-addy/src/main/java/com/peauty/addy/dalle/DalleEditImageResponse.java
+++ b/peauty-addy/src/main/java/com/peauty/addy/dalle/DalleEditImageResponse.java
@@ -1,0 +1,13 @@
+package com.peauty.addy.dalle;
+
+import java.util.List;
+
+public record DalleEditImageResponse(
+        Long created,
+        List<ImageData> data
+) {
+    public record ImageData(
+            String url
+    ) {
+    }
+}

--- a/peauty-addy/src/main/java/com/peauty/addy/dalle/ImageMaskGenerator.java
+++ b/peauty-addy/src/main/java/com/peauty/addy/dalle/ImageMaskGenerator.java
@@ -1,0 +1,96 @@
+package com.peauty.addy.dalle;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.nio.file.Files;
+
+@Component
+public class ImageMaskGenerator {
+
+    public MultipartFile createMask(MultipartFile originalImageFile, Point[] points) throws IOException {
+        if (points.length != 4) {
+            throw new IllegalArgumentException("정확히 4개의 점이 필요합니다.");
+        }
+
+        // 원본 이미지를 BufferedImage로 변환
+        BufferedImage originalImage = ImageIO.read(originalImageFile.getInputStream());
+
+        // 원본 이미지와 동일한 크기의 새 이미지 생성
+        BufferedImage maskedImage = new BufferedImage(
+                originalImage.getWidth(),
+                originalImage.getHeight(),
+                BufferedImage.TYPE_INT_ARGB
+        );
+
+        // 원본 이미지를 새 이미지에 복사
+        Graphics2D g2d = maskedImage.createGraphics();
+        g2d.drawImage(originalImage, 0, 0, null);
+
+        // 마스킹할 영역을 투명하게 만들기
+        g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.CLEAR));
+
+        // 점들로 다각형 생성
+        int[] xPoints = new int[points.length];
+        int[] yPoints = new int[points.length];
+        for (int i = 0; i < points.length; i++) {
+            xPoints[i] = points[i].x;
+            yPoints[i] = points[i].y;
+        }
+
+        // 지정된 영역을 투명하게 만들기
+        g2d.fillPolygon(xPoints, yPoints, points.length);
+        g2d.dispose();
+
+        // BufferedImage를 MultipartFile로 변환
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(maskedImage, "PNG", baos);
+        byte[] imageBytes = baos.toByteArray();
+
+        return new MultipartFile() {
+            @Override
+            public String getName() {
+                return "masked_" + originalImageFile.getOriginalFilename();
+            }
+
+            @Override
+            public String getOriginalFilename() {
+                return "masked_" + originalImageFile.getOriginalFilename();
+            }
+
+            @Override
+            public String getContentType() {
+                return "image/png";
+            }
+
+            @Override
+            public boolean isEmpty() {
+                return imageBytes.length == 0;
+            }
+
+            @Override
+            public long getSize() {
+                return imageBytes.length;
+            }
+
+            @Override
+            public byte[] getBytes() throws IOException {
+                return imageBytes;
+            }
+
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return new ByteArrayInputStream(imageBytes);
+            }
+
+            @Override
+            public void transferTo(File dest) throws IOException {
+                Files.write(dest.toPath(), imageBytes);
+            }
+        };
+    }
+}

--- a/peauty-addy/src/main/resources/application.properties
+++ b/peauty-addy/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=peauty-addy

--- a/peauty-addy/src/main/resources/application.yml
+++ b/peauty-addy/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  cloud:
+    openfeign:
+      autoconfiguration:
+        jackson:
+          enabled: true
+      httpclient:
+        connection-timeout: 5000
+        ok-http:
+          read-timeout: 60000
+openai:
+  api:
+    key: ${OPENAPI_KEY}


### PR DESCRIPTION
## 📄 [PEAUTY-213] Impl image generator and dalle client

Jira : [PEAUTY-213](https://multicampusuplus.atlassian.net/browse/PEAUTY-213?atlOrigin=eyJpIjoiMzQ5NmYxNGIzYTcwNDk3YzgyYzE2MjEyMTg4MDBhMTQiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명

- 원본이미지와 4 좌표를 받아 원본이미지에 해당 4좌표 사각형만큼 마스킹한 이미지를 만들어내는 기능을 구현했습니다
- Feign 클라이언트를 사용해 달리 이미지 에딧 클라이언트를 만들었습니다
- .env 에 open api key 를 추가했습니다  

<!-- Pull Request의 설명을 추가하세요. -->

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.3 MD
- Actual MD: 0.3 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
