### PR TITLE
[PEAUTY-temp7] Enhance Workspace Update API to Handle All Scenarios

### DIFF
--- a/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
@@ -59,42 +59,6 @@ public class WorkspaceAdapter implements WorkspacePort {
         return workspace;
     }
 
-//    @Override
-//    public Workspace updateDesginerWorkspace(Long userId, Workspace workspace) {
-//        WorkspaceEntity workspaceEntityToUpdate = WorkspaceMapper.toEntity(workspace, userId);
-//
-//        WorkspaceEntity updatedWorkspaceEntity =
-//                workspaceRepository.save(workspaceEntityToUpdate);
-//
-//        RatingEntity ratingEntity =
-//                ratingRepository.findByWorkspaceId(workspaceEntityToUpdate.getId())
-//                .orElse(null);
-//
-//        // 1. 기존 이미지 가져오기
-//        List<BannerImageEntity> bannerImageEntitiesToUpdate =
-//                bannerImageRepository.findByWorkspaceId(workspaceEntityToUpdate.getId());
-//
-//        // 2. 변경해야 하는 URL 가져오기
-//        List<String> updatedUrls = workspace.getBannerImageUrls(); // 새로운 URL 리스트
-//
-//        // 3. 동일한 URL 은 그냥 두고, 새로운 URL은 업데이트하기 단, 매핑이 되지 않은 기존 데이터는 삭제하기
-//
-//        List<BannerImageEntity> updatedBannerImageEntities = IntStream.range(0, Math.min(bannerImageEntitiesToUpdate.size(), updatedUrls.size()))
-//                .mapToObj(i -> {
-//                    BannerImageEntity entity = bannerImageEntitiesToUpdate.get(i);
-//                    entity.updateBannerImageUrl(updatedUrls.get(i)); // URL만 업데이트
-//                    return entity;
-//                })
-//                .toList();
-//
-//        List<BannerImageEntity> savedBannerImageEntities = bannerImageRepository.saveAll(updatedBannerImageEntities);
-//
-//        Rating rating = WorkspaceMapper.toRatingDomain(ratingEntity);
-//        Workspace updatedWorkspace = WorkspaceMapper.toDomain(updatedWorkspaceEntity, savedBannerImageEntities);
-//        updatedWorkspace.updateRating(rating);
-//        return updatedWorkspace;
-//    }
-
     @Override
     public Workspace updateDesginerWorkspace(Long userId, Workspace workspace) {
         // 1. Workspace 업데이트

--- a/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
@@ -5,7 +5,6 @@ import com.peauty.domain.designer.Rating;
 import com.peauty.domain.designer.Workspace;
 import com.peauty.domain.exception.PeautyException;
 import com.peauty.domain.response.PeautyResponseCode;
-import com.peauty.persistence.designer.license.LicenseRepository;
 import com.peauty.persistence.designer.mapper.WorkspaceMapper;
 import com.peauty.persistence.designer.rating.RatingEntity;
 import com.peauty.persistence.designer.rating.RatingRepository;

--- a/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/implementation/workspace/WorkspaceAdapter.java
@@ -68,6 +68,7 @@ public class WorkspaceAdapter implements WorkspacePort {
         // 2. Rating 조회
         RatingEntity ratingEntity = ratingRepository.findByWorkspaceId(workspaceEntityToUpdate.getId()).orElse(null);
 
+        // TODO. 나만 쓰기 아깝다.. 메서드로 뺴서 팀원 모두가 사용할 수 있게 해보자!
         // 3. 기존 배너 이미지 엔티티 가져오기
         List<BannerImageEntity> existingEntities = bannerImageRepository.findByWorkspaceId(workspaceEntityToUpdate.getId());
 
@@ -86,7 +87,7 @@ public class WorkspaceAdapter implements WorkspacePort {
                 .collect(Collectors.toList());
 
         // 추가할 엔티티: 새로운 URL 중 기존에 없는 것
-        List<BannerImageEntity> entitiesToAdd = updatedUrls.stream()
+        List<BannerImageEntity> entitiesToUpdate = updatedUrls.stream()
                 .filter(url -> !existingUrls.contains(url))
                 .map(url -> BannerImageEntity.builder()
                         .workspaceId(workspaceEntityToUpdate.getId())
@@ -95,7 +96,7 @@ public class WorkspaceAdapter implements WorkspacePort {
                 .collect(Collectors.toList());
 
         bannerImageRepository.deleteAll(entitiesToDelete);
-        bannerImageRepository.saveAll(entitiesToAdd);
+        bannerImageRepository.saveAll(entitiesToUpdate);
 
         // 6. 최종 배너 이미지 리스트 조회
         List<BannerImageEntity> finalBannerImageEntities =

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/workspace/BannerImageEntity.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/workspace/BannerImageEntity.java
@@ -20,6 +20,6 @@ public class BannerImageEntity extends BaseTimeEntity {
     private Long workspaceId;
 
     @Lob
-    @Column(name = "banner_image_url", nullable = true)
+    @Column(name = "banner_image_url")
     private String bannerImageUrl;
 }

--- a/peauty-persistence/src/main/java/com/peauty/persistence/designer/workspace/BannerImageEntity.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/designer/workspace/BannerImageEntity.java
@@ -22,8 +22,4 @@ public class BannerImageEntity extends BaseTimeEntity {
     @Lob
     @Column(name = "banner_image_url", nullable = true)
     private String bannerImageUrl;
-
-    public void updateBannerImageUrl(String s) {
-        this.bannerImageUrl = s;
-    }
 }


### PR DESCRIPTION
## 📄 [PF-temp7] Enhance Workspace Update API to Handle All Scenarios

Jira : [PEAUTY-temp7](temp7)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명
- [x] 버그 수정 설명
- [x] 문서 수정 설명

<!-- Pull Request의 설명을 추가하세요. -->
- update API의 경우, 기존에 저장된 DB를 가져와서 수정되는 값만 고쳐야 하는 상황이었습니다.
- 이 경우 db에 1개의 데이터가 있고 update로 2개 데이터를 입력하려고 할 때 한개의 데이터만 수정되어 다른 데이터가 유실되는 경우가 있었습니다.
- 그래서 모든 경우에 update를 할 수 있게 개발했습니다.(기존의 db데이터가 업데이트 데이터보다 적을 때, 많을 때, 같을 때)
- 다만, 스트림을 사용하여 조금 더 짧게 만들 수 있지 않을까.. 라는 생각도 듭니다.


## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.3MD
- Actual MD: 0.3MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
