### PR TITLE
[PEAUTY-temp13] Adding biddingProcessId info in Review

### DIFF
--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/BiddingProcessPort.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/bidding/BiddingProcessPort.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 public interface BiddingProcessPort {
 
     BiddingProcess getProcessByProcessId(Long processId);
+    BiddingProcess getProcessByThreadId(Long threadId);
     List<BiddingProcess> getProcessesByPuppyId(Long puppyId);
     Optional<BiddingProcess> findOngoingProcessByPuppyId(Long puppyId);
     BiddingProcess getProcessByProcessIdAndPuppyId(Long processId, Long puppyId);

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/review/ReviewServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/review/ReviewServiceImpl.java
@@ -20,6 +20,7 @@ import com.peauty.domain.review.Review;
 import com.peauty.domain.review.ReviewImage;
 import com.peauty.domain.review.ReviewRating;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +29,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class ReviewServiceImpl implements ReviewService {
 
     private final ReviewPort reviewPort;
@@ -198,7 +200,7 @@ public class ReviewServiceImpl implements ReviewService {
 
         List<GetReviewDetailResult> reviewDetails = reviews.stream()
                 .map(review -> {
-                    BiddingProcess process = biddingProcessPort.getProcessByProcessId(review.getThreadId().value());
+                    BiddingProcess process = biddingProcessPort.getProcessByThreadId(review.getThreadId().value());
                     EstimateProposal proposal = estimateProposalPort.getProposalByProcessId(process.getSavedProcessId().value());
                     Puppy puppy = puppyPort.getPuppyByPuppyId(process.getPuppyId().value());
                     Designer.DesignerProfile designerProfile = designerPort.getDesignerProfileByDesignerId(

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/review/ReviewServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/review/ReviewServiceImpl.java
@@ -143,11 +143,12 @@ public class ReviewServiceImpl implements ReviewService {
         Designer.DesignerProfile designerProfile = designerPort.getDesignerProfileByDesignerId(thread.getDesignerId().value());
         String groomingStyle = proposal.getSimpleGroomingStyle();
         Long desiredCost = proposal.getDesiredCost();
+        Long biddingProcessId = process.getSavedProcessId().value();
 
         Puppy puppy = puppyPort.getPuppyByPuppyId(puppyId);
         String puppyName = puppy.getName();
 
-        return GetReviewDetailResult.from(review, puppyName, desiredCost, groomingStyle, designerProfile);
+        return GetReviewDetailResult.from(review, puppyName, desiredCost, groomingStyle, designerProfile, biddingProcessId);
 
     }
 
@@ -209,7 +210,8 @@ public class ReviewServiceImpl implements ReviewService {
                             puppy.getName(),
                             proposal.getDesiredCost(),
                             proposal.getSimpleGroomingStyle(),
-                            designerProfile
+                            designerProfile,
+                            process.getSavedProcessId().value()
                     );
                 }).toList();
 

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/review/dto/GetReviewDetailResult.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/review/dto/GetReviewDetailResult.java
@@ -15,6 +15,7 @@ import java.util.List;
 public record GetReviewDetailResult(
         Review.ID reviewId,
         BiddingThread.ID biddingThreadId,
+        Long biddingProcessId,
         Double reviewRating,
         String contentDetail,
         List<String> contentGenerals,
@@ -33,10 +34,11 @@ public record GetReviewDetailResult(
     }
 
 
-    public static GetReviewDetailResult from(Review review, String puppyName, Long estimateCost, String groomingStyle, Designer.DesignerProfile designerProfile) {
+    public static GetReviewDetailResult from(Review review, String puppyName, Long estimateCost, String groomingStyle, Designer.DesignerProfile designerProfile, Long biddingProcessId) {
         return new GetReviewDetailResult(
                 review.getSavedReviewId(),
                 review.getThreadId(),
+                biddingProcessId,
                 review.getReviewRating().getValue(),
                 review.getContentDetail(),
                 review.getContentGenerals().stream()

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/bidding/BiddingProcessAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/bidding/BiddingProcessAdapter.java
@@ -63,6 +63,14 @@ public class BiddingProcessAdapter implements BiddingProcessPort {
     }
 
     @Override
+    public BiddingProcess getProcessByThreadId(Long threadId) {
+        BiddingProcessEntity foundProcessEntity = processRepository.findByThreadId(threadId)
+                .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_FOUND_BIDDING_PROCESS));
+        List<BiddingThreadEntity> foundThreadEntities = threadRepository.findByBiddingProcessId(foundProcessEntity.getId());
+        return BiddingMapper.toProcessDomain(foundProcessEntity, foundThreadEntities);
+    }
+
+    @Override
     public BiddingProcess getProcessByProcessIdAndPuppyId(Long processId, Long puppyId) {
         BiddingProcessEntity foundProcessEntity = processRepository.findByIdAndPuppyId(processId, puppyId)
                 .orElseThrow(() -> new PeautyException(PeautyResponseCode.NOT_FOUND_BIDDING_PROCESS));

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/review/dto/GetReviewDetailResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/review/dto/GetReviewDetailResponse.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record GetReviewDetailResponse(
         Long reviewId,
         Long biddingThreadId,
+        Long biddingProcessId,
         Double reviewRating,
         String contentDetail,
         List<String> contentGenerals,
@@ -23,6 +24,7 @@ public record GetReviewDetailResponse(
         return new GetReviewDetailResponse(
                 result.reviewId().value(),
                 result.biddingThreadId().value(),
+                result.biddingProcessId(),
                 result.reviewRating(),
                 result.contentDetail(),
                 result.contentGenerals(),

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/review/dto/GetUserReviewsResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/review/dto/GetUserReviewsResponse.java
@@ -7,12 +7,14 @@ import java.util.List;
 
 public record GetUserReviewsResponse(
         Long customerId,
-        List<GetReviewDetailResult> reviews
+        List<GetReviewDetailResponse> reviews
 ) {
     public static GetUserReviewsResponse from(GetUserReviewsResult result) {
         return new GetUserReviewsResponse(
                 result.customerId(),
-                result.reviews()
+                result.reviews().stream()
+                        .map(GetReviewDetailResponse::from)
+                        .toList()
         );
     }
 }

--- a/peauty-persistence/src/main/java/com/peauty/persistence/bidding/process/BiddingProcessRepository.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/bidding/process/BiddingProcessRepository.java
@@ -14,6 +14,8 @@ public interface BiddingProcessRepository extends JpaRepository<BiddingProcessEn
 
     List<BiddingProcessEntity> findByPuppyId(@Param("puppyId") Long puppyId);
     Optional<BiddingProcessEntity> findByIdAndPuppyId(@Param("processId") Long processId, @Param("puppyId") Long puppyId);
+    @Query("SELECT t.biddingProcess FROM BiddingThreadEntity t WHERE t.id = :threadId")
+    Optional<BiddingProcessEntity> findByThreadId(@Param("threadId") Long threadId);
     long countByPuppyIdAndStatusIn(@Param("puppyId") Long puppyId, List<BiddingProcessStatus> statuses);
 
     @Query("SELECT bp FROM BiddingProcessEntity bp " +


### PR DESCRIPTION
## 📄 [PEAUTY-temp13] Adding biddingProcessId info in Review

Jira : [PEAUTY-temp13]

## ✨ 변경 사항
- [ ] 기능 추가/변경 설명
- [ ] 버그 수정 설명
- [ ] 문서 수정 설명

<!-- Pull Request의 설명을 추가하세요. -->

전체 조회 이후 수정 및 삭제를 위해 biddingProcessId 정보를 추가적으로 제공합니다.
및 designerProfile을 통해서 가져오던 reviewId 등이 value : " "식으로 오던 것을 수정했습니다.
현재 전체 조회를 할 시 나오는 Response Body는 다음과 같습니다.
{
  "responseCode": "0000",
  "errorMessage": "OK",
  "serviceErrorMessage": "정상 처리되었습니다.",
  "data": {
    "customerId": 1,
    "reviews": [
      {
        "reviewId": 1,
        "biddingThreadId": 1,
        "biddingProcessId": 1,
        "reviewRating": 5,
        "contentDetail": "string",
        "contentGenerals": [
          "서비스가 좋아요"
        ],
        "reviewImages": [
          "string"
        ],
        "groomingStyle": "알머리 + 클리핑컷",
        "puppyName": "몽이",
        "estimateCost": 0,
        "reviewCreatedAt": "2024-12-17",
        "designerProfile": {
          "workspaceName": "스타일하우스",
          "address": "서울시 강남구 역삼동"
        }
      }
    ]
  }
}


## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.3MD
- Actual MD: 0.5MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [ ] 코드가 잘 작동하는지 확인했나요?
- [ ] 새로운 기능에 대한 테스트가 추가되었나요?
- [ ] 문서가 업데이트되었나요?
