### PR TITLE
[PEAUTY-248]  Add field puppyId - GetUserReviews

### DIFF
--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/review/ReviewServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/review/ReviewServiceImpl.java
@@ -150,7 +150,7 @@ public class ReviewServiceImpl implements ReviewService {
         Puppy puppy = puppyPort.getPuppyByPuppyId(puppyId);
         String puppyName = puppy.getName();
 
-        return GetReviewDetailResult.from(review, puppyName, desiredCost, groomingStyle, designerProfile, biddingProcessId);
+        return GetReviewDetailResult.from(review, puppyId, puppyName, desiredCost, groomingStyle, designerProfile, biddingProcessId);
 
     }
 
@@ -209,6 +209,7 @@ public class ReviewServiceImpl implements ReviewService {
 
                     return GetReviewDetailResult.from(
                             review,
+                            puppy.getPuppyId(),
                             puppy.getName(),
                             proposal.getDesiredCost(),
                             proposal.getSimpleGroomingStyle(),

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/review/ReviewServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/review/ReviewServiceImpl.java
@@ -150,7 +150,7 @@ public class ReviewServiceImpl implements ReviewService {
         Puppy puppy = puppyPort.getPuppyByPuppyId(puppyId);
         String puppyName = puppy.getName();
 
-        return GetReviewDetailResult.from(review, puppyId, puppyName, desiredCost, groomingStyle, designerProfile, biddingProcessId);
+        return GetReviewDetailResult.from(review, puppy, puppyName, desiredCost, groomingStyle, designerProfile, biddingProcessId);
 
     }
 
@@ -209,7 +209,7 @@ public class ReviewServiceImpl implements ReviewService {
 
                     return GetReviewDetailResult.from(
                             review,
-                            puppy.getPuppyId(),
+                            puppy,
                             puppy.getName(),
                             proposal.getDesiredCost(),
                             proposal.getSimpleGroomingStyle(),

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/review/dto/GetReviewDetailResult.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/review/dto/GetReviewDetailResult.java
@@ -34,13 +34,13 @@ public record GetReviewDetailResult(
 
     }
 
-
-    public static GetReviewDetailResult from(Review review, Long puppyId, String puppyName, Long estimateCost, String groomingStyle, Designer.DesignerProfile designerProfile, Long biddingProcessId) {
+// TODO: 추후 puppyName을 Puppy 내에서 받아오게 리팩토링 예정, estimateCost 등도 도메인 내에서 받아올 수 있도록 수정 예정.
+    public static GetReviewDetailResult from(Review review, Puppy puppy, String puppyName, Long estimateCost, String groomingStyle, Designer.DesignerProfile designerProfile, Long biddingProcessId) {
         return new GetReviewDetailResult(
                 review.getSavedReviewId(),
                 review.getThreadId(),
                 biddingProcessId,
-                puppyId,
+                puppy.getPuppyId(),
                 review.getReviewRating().getValue(),
                 review.getContentDetail(),
                 review.getContentGenerals().stream()

--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/review/dto/GetReviewDetailResult.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/review/dto/GetReviewDetailResult.java
@@ -16,6 +16,7 @@ public record GetReviewDetailResult(
         Review.ID reviewId,
         BiddingThread.ID biddingThreadId,
         Long biddingProcessId,
+        Long puppyId,
         Double reviewRating,
         String contentDetail,
         List<String> contentGenerals,
@@ -34,11 +35,12 @@ public record GetReviewDetailResult(
     }
 
 
-    public static GetReviewDetailResult from(Review review, String puppyName, Long estimateCost, String groomingStyle, Designer.DesignerProfile designerProfile, Long biddingProcessId) {
+    public static GetReviewDetailResult from(Review review, Long puppyId, String puppyName, Long estimateCost, String groomingStyle, Designer.DesignerProfile designerProfile, Long biddingProcessId) {
         return new GetReviewDetailResult(
                 review.getSavedReviewId(),
                 review.getThreadId(),
                 biddingProcessId,
+                puppyId,
                 review.getReviewRating().getValue(),
                 review.getContentDetail(),
                 review.getContentGenerals().stream()

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/review/dto/GetReviewDetailResponse.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/review/dto/GetReviewDetailResponse.java
@@ -13,6 +13,8 @@ public record GetReviewDetailResponse(
         Long biddingThreadId,
         @Schema(description = "리뷰 프로세스 ID(FK)", example = "1")
         Long biddingProcessId,
+        @Schema(description = "강아지 ID(FK)", example = "1") // 추가
+        Long puppyId,
         @Schema(description = "리뷰 평점", example = "FOUR")
         Double reviewRating,
         @Schema(description = "리뷰 내용", example = "그럭저럭이었어요.")
@@ -37,6 +39,7 @@ public record GetReviewDetailResponse(
                 result.reviewId().value(),
                 result.biddingThreadId().value(),
                 result.biddingProcessId(),
+                result.puppyId(),
                 result.reviewRating(),
                 result.contentDetail(),
                 result.contentGenerals(),


### PR DESCRIPTION
## 📄 [PEAUTY-248]  Add field puppyId - GetUserReviews

Jira : [PEAUTY-248](https://multicampusuplus.atlassian.net/browse/PEAUTY-248?atlOrigin=eyJpIjoiMTdmZDBhNWVlMGVhNDJlNzlmNDY3NmRjNWQxZDEzOWIiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명
- [x] 버그 수정 설명
- [x] 문서 수정 설명

<!-- Pull Request의 설명을 추가하세요. -->

유저의 리뷰 전체 조회를 할 시 puppyId를 추가적으로 Response Body에 내려줍니다.
이를 통해, 수정과 삭제할 때 필요한 userId, processId, threadId, puppyId가 다 있기 때문에
프론트 측에서 다른 API를 통해 필요한 ID를 받아올 필요가 없어집니다.


## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.1 MD
- Actual MD: 0.2 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
