### PR TITLE
[PEAUTY-temp11] Impl get designer schedule

### DIFF
--- a/peauty-customer-api/src/main/java/com/peauty/customer/business/auth/AuthServiceImpl.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/business/auth/AuthServiceImpl.java
@@ -33,7 +33,7 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public SignUpResult signUp(SignUpCommand command) {
         customerPort.checkCustomerSocialIdDuplicated(command.socialId());
-        customerPort.checkCustomerPhoneNumberDuplicated(command.phoneNumber());
+//        customerPort.checkCustomerPhoneNumberDuplicated(command.phoneNumber()); TODO 중복검사 다시 하기
         customerPort.checkCustomerNicknameDuplicated(command.nickname());
         Customer registeredCustomer = customerPort.registerNewCustomer(command);
         SignTokens signTokens = authPort.generateSignTokens(registeredCustomer.getAuthInfo());

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/bidding/dto/SendEstimateProposalRequest.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/bidding/dto/SendEstimateProposalRequest.java
@@ -4,6 +4,7 @@ import com.peauty.customer.business.bidding.dto.SendEstimateProposalCommand;
 import com.peauty.domain.bidding.GroomingType;
 import com.peauty.domain.bidding.TotalGroomingBodyType;
 import com.peauty.domain.bidding.TotalGroomingFaceType;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,6 +15,7 @@ public record SendEstimateProposalRequest(
         String detail,
         List<String> imageUrls,
         Long desiredCost,
+        @Schema(description = "미용을 원하는 시간입니다 지금은 예시처럼 타입을 맞춰주세요!", example = "2024-12-18 15:45")
         String desiredDateTime,
         TotalGroomingBodyType totalGroomingBodyType,
         TotalGroomingFaceType totalGroomingFaceType

--- a/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/CustomerController.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/presentation/controller/customer/CustomerController.java
@@ -30,8 +30,6 @@ public class CustomerController {
     @PostMapping(value = "/users/{userId}/profile/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "고객 프로필 이미지 업로드", description = "고객의 프로필 이미지 업로드 API 진입점입니다.")
     public UploadProfileImageResponse uploadProfileImage(@PathVariable Long userId, @RequestParam("image") MultipartFile image) {
-        LocalDateTime time = LocalDateTime.now();
-        LocalDate dateTIme = time.toLocalDate();
         UploadProfileImageResult result = customerService.uploadProfileImage(userId, image);
         return UploadProfileImageResponse.from(result);
     }

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/auth/AuthServiceImpl.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/auth/AuthServiceImpl.java
@@ -33,7 +33,7 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public SignUpResult signUp(SignUpCommand command) {
-        designerPort.checkDesignerPhoneNumDuplicated(command.phoneNumber());
+//        designerPort.checkDesignerPhoneNumDuplicated(command.phoneNumber());  TODO 중복검사 다시 하기
         designerPort.checkDesignerNicknameDuplicated(command.nickname());
         Designer registeredCustomer = designerPort.registerNewDesigner(command);
         SignTokens signTokens = authPort.generateSignTokens(registeredCustomer.getAuthInfo());

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/DesignerBiddingService.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/DesignerBiddingService.java
@@ -23,6 +23,8 @@ public interface DesignerBiddingService {
             Long threadId
     );
 
+    GetDesignerScheduleResult getDesignerSchedule(Long userId);
+
     GetThreadsByStepResult getStep3AboveThreads(Long userId);
 
     GetThreadsByStepResult getStep2Threads(Long userId);

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/DesignerBiddingServiceImpl.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/DesignerBiddingServiceImpl.java
@@ -1,14 +1,22 @@
 package com.peauty.designer.business.bidding;
 
 import com.peauty.designer.business.bidding.dto.*;
+import com.peauty.designer.business.designer.DesignerPort;
 import com.peauty.designer.business.puppy.PuppyPort;
+import com.peauty.designer.business.workspace.WorkspacePort;
 import com.peauty.domain.bidding.*;
 import com.peauty.domain.puppy.Puppy;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +27,8 @@ public class DesignerBiddingServiceImpl implements DesignerBiddingService {
     private final EstimateProposalPort estimateProposalPort;
     private final EstimatePort estimatePort;
     private final PuppyPort puppyPort;
+    private final DesignerPort designerPort;
+    private final WorkspacePort workspacePort;
 
     @Override
     @Transactional
@@ -64,6 +74,53 @@ public class DesignerBiddingServiceImpl implements DesignerBiddingService {
                 puppy,
                 estimateProposal,
                 estimate
+        );
+    }
+
+    // TODO 말도 안되는 쿼리가 날라가는데 반드시 고쳐야합니다..
+    @Override
+    public GetDesignerScheduleResult getDesignerSchedule(Long userId) {
+        AtomicInteger completedCount = new AtomicInteger(0);
+        AtomicInteger todayCount = new AtomicInteger(0);
+        AtomicInteger futureCount = new AtomicInteger(0);
+
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        DesignerId designerId = new DesignerId(userId);
+
+        return GetDesignerScheduleResult.from(
+                designerPort.getByDesignerId(userId).getProfile(workspacePort.getByDesignerId(userId)),
+                biddingProcessPort.getProcessesByDesignerId(userId)
+                        .stream()
+                        .filter(process -> process.getThread(designerId).getStep().isAfter(BiddingThreadStep.ESTIMATE_RESPONSE))
+                        .peek(process -> {
+                            BiddingThread thread = process.getThread(designerId);
+                            BiddingThreadStep step = thread.getStep();
+
+                            if (step == BiddingThreadStep.COMPLETED) {
+                                completedCount.incrementAndGet();
+                            }
+
+                            if (step.isAfter(BiddingThreadStep.ESTIMATE_RESPONSE)) {
+                                String desiredDateTime = estimateProposalPort.getProposalByProcessId(process.getSavedProcessId().value()).getDesiredDateTime();
+
+                                // TODO LocalDateTime 포맷을 가진 값 객체 도입이 시급
+                                if (desiredDateTime.startsWith(today)) {
+                                    todayCount.incrementAndGet();
+                                } else if (desiredDateTime.compareTo(today) > 0) {
+                                    futureCount.incrementAndGet();
+                                }
+                            }
+                        })
+                        .filter(process -> estimateProposalPort.getProposalByProcessId(process.getSavedProcessId().value())
+                                .getDesiredDateTime().startsWith(today))
+                        .map(process -> process.getProfile(
+                                puppyPort.getPuppyByPuppyId(process.getPuppyId().value()).getProfile(),
+                                estimateProposalPort.getProposalByProcessId(process.getSavedProcessId().value()).getProfile(),
+                                designerId,
+                                estimatePort.getEstimateByThreadId(process.getThread(designerId).getSavedThreadId().value()).getProfile()
+                        ))
+                        .toList(),
+                completedCount.get(), todayCount.get(), futureCount.get()
         );
     }
 

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/dto/GetDesignerScheduleResult.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/bidding/dto/GetDesignerScheduleResult.java
@@ -1,0 +1,40 @@
+package com.peauty.designer.business.bidding.dto;
+
+import com.peauty.domain.bidding.BiddingProcess;
+import com.peauty.domain.designer.Designer;
+import lombok.Builder;
+
+import java.util.List;
+
+public record GetDesignerScheduleResult(
+        Designer.DesignerProfile designerProfile,
+        List<BiddingProcess.ProcessProfile> processProfiles,
+        GetDesignerScheduleResultGroomingSummary groomingSummary
+) {
+
+    @Builder
+    public record GetDesignerScheduleResultGroomingSummary(
+            Integer endGroomingCount,
+            Integer todayGroomingCount,
+            Integer nextGroomingCount
+    ) {
+    }
+
+    public static GetDesignerScheduleResult from(
+            Designer.DesignerProfile designerProfile,
+            List<BiddingProcess.ProcessProfile> processProfiles,
+            Integer endGroomingCount,
+            Integer todayGroomingCount,
+            Integer nextGroomingCount
+    ) {
+        return new GetDesignerScheduleResult(
+                designerProfile,
+                processProfiles,
+                new GetDesignerScheduleResultGroomingSummary(
+                        endGroomingCount,
+                        todayGroomingCount,
+                        nextGroomingCount
+                )
+        );
+    }
+}

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/config/SwaggerConfig.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/config/SwaggerConfig.java
@@ -43,7 +43,7 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .info(info)
-                .servers(List.of(server))
+//                .servers(List.of(server))
                 .addSecurityItem(securityRequirement)
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme));
     }

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/config/SwaggerConfig.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/config/SwaggerConfig.java
@@ -43,7 +43,7 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .info(info)
-//                .servers(List.of(server))
+                .servers(List.of(server))
                 .addSecurityItem(securityRequirement)
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme));
     }

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/bidding/DesignerBiddingController.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/bidding/DesignerBiddingController.java
@@ -62,6 +62,13 @@ public class DesignerBiddingController {
         return GetEstimateAndProposalDetailsResponse.from(result);
     }
 
+    @GetMapping("/{userId}/bidding/processes/threads/schedule")
+    @Operation(summary = "디자이너 스케줄 조회", description = "디자이너의 프로필, 미용 , 오늘의 예약들을 가져옵니다.")
+    public GetDesignerScheduleResponse getDesignerSchedule(@PathVariable Long userId) {
+        GetDesignerScheduleResult result = designerBiddingService.getDesignerSchedule(userId);
+        return GetDesignerScheduleResponse.from(result);
+    }
+
     @GetMapping("/{userId}/bidding/processes/threads/above-step3")
     @Operation(summary = "확정 견적 조회", description = "디자이너와 연관된 스레드들 중 Step 3 이상의 스레드들을 조회.")
     public GetThreadsByStepResponse getStep3AboveThreads(@PathVariable Long userId) {

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/bidding/dto/GetDesignerScheduleResponse.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/bidding/dto/GetDesignerScheduleResponse.java
@@ -1,0 +1,91 @@
+package com.peauty.designer.presentation.controller.bidding.dto;
+
+import com.peauty.designer.business.bidding.dto.GetDesignerScheduleResult;
+import com.peauty.domain.designer.Badge;
+import com.peauty.domain.designer.Scissors;
+import com.peauty.domain.puppy.Puppy;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetDesignerScheduleResponse(
+        GetDesignerScheduleResponseWorkspace workspace,
+        GetDesignerScheduleResponseGroomingSummary groomingSummary,
+        List<GetDesignerScheduleResponseThread> threads
+) {
+
+    @Builder
+    public record GetDesignerScheduleResponseWorkspace(
+            Long designerId,
+            String designerProfileImageUrl,
+            String workspaceName,
+            Integer reviewCount,
+            Double reviewRating,
+            List<Badge> badges,
+            String address,
+            Scissors scissors
+    ) {
+    }
+
+    @Builder
+    public record GetDesignerScheduleResponseGroomingSummary(
+            Integer endGroomingCount,
+            Integer todayGroomingCount,
+            Integer nextGroomingCount
+    ) {
+    }
+
+    @Builder
+    public record GetDesignerScheduleResponseThread(
+            Long processId,
+            String processStatus,
+            LocalDateTime processCreatedAt,
+            LocalDateTime processStatusModifiedAt,
+            Long threadId,
+            String threadStep,
+            String threadStatus,
+            LocalDateTime threadCreatedAt,
+            LocalDateTime threadStepModifiedAt,
+            Long depositPrice,
+            String desiredGroomingDateTime,
+            Puppy.PuppyProfile puppy
+    ) {
+    }
+
+    public static GetDesignerScheduleResponse from(GetDesignerScheduleResult result) {
+        return new GetDesignerScheduleResponse(
+                GetDesignerScheduleResponseWorkspace.builder()
+                        .designerId(result.designerProfile().designerId())
+                        .designerProfileImageUrl(result.designerProfile().profileImageUrl())
+                        .workspaceName(result.designerProfile().workspaceName())
+                        .reviewCount(result.designerProfile().reviewCount())
+                        .reviewRating(result.designerProfile().reviewRating())
+                        .badges(result.designerProfile().badges())
+                        .address(result.designerProfile().address())
+                        .scissors(result.designerProfile().scissors())
+                        .build(),
+                GetDesignerScheduleResponseGroomingSummary.builder()
+                        .endGroomingCount(result.groomingSummary().endGroomingCount())
+                        .todayGroomingCount(result.groomingSummary().todayGroomingCount())
+                        .nextGroomingCount(result.groomingSummary().nextGroomingCount())
+                        .build(),
+                result.processProfiles().stream()
+                        .map(processProfile -> GetDesignerScheduleResponseThread.builder()
+                                .processId(processProfile.processId())
+                                .processStatus(processProfile.processStatus())
+                                .processCreatedAt(processProfile.processCreatedAt())
+                                .processStatusModifiedAt(processProfile.processStatusModifiedAt())
+                                .threadId(processProfile.threadInfo().threadId())
+                                .threadStep(processProfile.threadInfo().threadStep())
+                                .threadStatus(processProfile.threadInfo().threadStatus())
+                                .threadCreatedAt(processProfile.threadInfo().threadCreatedAt())
+                                .threadStepModifiedAt(processProfile.threadInfo().threadStepModifiedAt())
+                                .depositPrice(processProfile.estimate().depositPrice())
+                                .desiredGroomingDateTime(processProfile.estimateProposal().desiredDateTime())
+                                .puppy(processProfile.puppy())
+                                .build())
+                        .toList()
+        );
+    }
+}

--- a/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/bidding/dto/GetDesignerScheduleResponse.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/presentation/controller/bidding/dto/GetDesignerScheduleResponse.java
@@ -4,54 +4,100 @@ import com.peauty.designer.business.bidding.dto.GetDesignerScheduleResult;
 import com.peauty.domain.designer.Badge;
 import com.peauty.domain.designer.Scissors;
 import com.peauty.domain.puppy.Puppy;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record GetDesignerScheduleResponse(
+        @Schema(description = "디자이너 작업공간 정보")
         GetDesignerScheduleResponseWorkspace workspace,
+
+        @Schema(description = "미용 예약 현황 요약")
         GetDesignerScheduleResponseGroomingSummary groomingSummary,
+
+        @Schema(description = "예약 스레드 목록")
         List<GetDesignerScheduleResponseThread> threads
 ) {
 
     @Builder
     public record GetDesignerScheduleResponseWorkspace(
+            @Schema(description = "디자이너 ID")
             Long designerId,
+
+            @Schema(description = "디자이너 프로필 이미지 URL")
             String designerProfileImageUrl,
+
+            @Schema(description = "작업공간 이름")
             String workspaceName,
+
+            @Schema(description = "리뷰 개수")
             Integer reviewCount,
+
+            @Schema(description = "리뷰 평점")
             Double reviewRating,
+
+            @Schema(description = "보유 뱃지 목록")
             List<Badge> badges,
+
+            @Schema(description = "작업공간 주소")
             String address,
+
+            @Schema(description = "디자이너 등급")
             Scissors scissors
-    ) {
-    }
+    ) {}
 
     @Builder
     public record GetDesignerScheduleResponseGroomingSummary(
+            @Schema(description = "완료된 미용 건수")
             Integer endGroomingCount,
+
+            @Schema(description = "오늘 예정된 미용 건수")
             Integer todayGroomingCount,
+
+            @Schema(description = "다음 예정된 미용 건수")
             Integer nextGroomingCount
-    ) {
-    }
+    ) {}
 
     @Builder
     public record GetDesignerScheduleResponseThread(
+            @Schema(description = "프로세스 ID")
             Long processId,
+
+            @Schema(description = "프로세스 상태")
             String processStatus,
+
+            @Schema(description = "프로세스 생성 시간")
             LocalDateTime processCreatedAt,
+
+            @Schema(description = "프로세스 상태 수정 시간")
             LocalDateTime processStatusModifiedAt,
+
+            @Schema(description = "스레드 ID")
             Long threadId,
+
+            @Schema(description = "스레드 단계")
             String threadStep,
+
+            @Schema(description = "스레드 상태")
             String threadStatus,
+
+            @Schema(description = "스레드 생성 시간")
             LocalDateTime threadCreatedAt,
+
+            @Schema(description = "스레드 단계 수정 시간")
             LocalDateTime threadStepModifiedAt,
+
+            @Schema(description = "예약금")
             Long depositPrice,
+
+            @Schema(description = "희망 미용 일시")
             String desiredGroomingDateTime,
+
+            @Schema(description = "반려견 프로필 정보")
             Puppy.PuppyProfile puppy
-    ) {
-    }
+    ) {}
 
     public static GetDesignerScheduleResponse from(GetDesignerScheduleResult result) {
         return new GetDesignerScheduleResponse(

--- a/peauty-domain/src/main/java/com/peauty/domain/bidding/BiddingProcess.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/bidding/BiddingProcess.java
@@ -225,6 +225,25 @@ public class BiddingProcess {
                 .build();
     }
 
+    public ProcessProfile getProfile(
+            Puppy.PuppyProfile puppyProfile,
+            EstimateProposal.EstimateProposalProfile estimateProposalProfile,
+            DesignerId designerId,
+            Estimate.EstimateProfile estimateProfile
+    ) {
+        BiddingThread thread = getThread(designerId);
+        return ProcessProfile.builder()
+                .processId(id.value())
+                .processStatus(status.getDescription())
+                .puppy(puppyProfile)
+                .estimateProposal(estimateProposalProfile)
+                .processCreatedAt(timeInfo.getCreatedAt())
+                .processStatusModifiedAt(timeInfo.getStatusModifiedAt())
+                .threadInfo(thread.getProfile())
+                .estimate(estimateProfile)
+                .build();
+    }
+
     @Builder
     public record ProcessProfile(
             Long processId,
@@ -233,7 +252,8 @@ public class BiddingProcess {
             LocalDateTime processStatusModifiedAt,
             Puppy.PuppyProfile puppy,
             EstimateProposal.EstimateProposalProfile estimateProposal,
-            BiddingThread.ThreadProfile threadInfo
+            BiddingThread.ThreadProfile threadInfo,
+            Estimate.EstimateProfile estimate
     ) {
     }
 }


### PR DESCRIPTION
## 📄 [PEAUTY-temp11] Impl get designer schedule

Jira : [PEAUTY-temp11](url)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명

- 프로젝션과 쿼리를 직접 만들지 않으니 약 12개의 테이블이 무자비하게 엮이게 되는 미완성 구현을 해냈습니다...
- 단순히 조인되는 테이블의 갯수가 문제가 아니라 쿼리가 너무 많이 나가기 때문에 커스텀 쿼리가 시급합니다
- 다만 현재 구현이 너무 급해 개발된 것들을 사용해 얼기설기 만들었습니다
- 최우선 리팩토링 대상
- 앗차 아직 스웨거 설정을 못했습니다 기달
<img width="791" alt="스크린샷 2024-12-18 오후 12 12 08" src="https://github.com/user-attachments/assets/38f06500-9820-46f4-b2ef-0774e11208c0" />


<!-- Pull Request의 설명을 추가하세요. -->

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.5 MD
- Actual MD: 0.5 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
