### PR TITLE
[PEAUTY-258] Workspace Update API for License Saving

### DIFF
--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerPort.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerPort.java
@@ -3,6 +3,7 @@ package com.peauty.designer.business.designer;
 import com.peauty.designer.business.auth.dto.SignUpCommand;
 import com.peauty.domain.designer.Badge;
 import com.peauty.domain.designer.Designer;
+import com.peauty.domain.designer.License;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,6 +31,7 @@ public interface DesignerPort {
 
     void updateBadgeStatus(Badge badge, Long userId);
 
-    Designer updateDesignerYearsOfExperience(Long userId, Integer YearsOfExperience);
+    Designer updateDesignerWhenUpdateWorkspace(
+            Long userId, Integer YearsOfExperience, List<License> licenses);
 }
 

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerServiceImpl.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/DesignerServiceImpl.java
@@ -96,8 +96,10 @@ public class DesignerServiceImpl implements DesignerService {
         Workspace workspaceToUpdate = workspacePort.getByDesignerId(userId);
         workspaceToUpdate.updateWorkspace(UpdateDesignerWorkspaceCommand.toWorkspace(command));
         workspaceToUpdate.updateBannerImgUrls(command.bannerImageUrls());
+        List<License> licenseToCreate = UpdateDesignerWorkspaceCommand.toLicense(command);
         Workspace updatedWorkspace = workspacePort.updateDesginerWorkspace(userId, workspaceToUpdate);
-        Designer savedDesigner = designerPort.updateDesignerYearsOfExperience(userId, command.yearOfExperience());
+        Designer savedDesigner = designerPort.updateDesignerWhenUpdateWorkspace(
+                userId, command.yearOfExperience(), licenseToCreate);
         //Designer getDesigner = designerPort.getAllDesignerDataByDesignerId(userId);
 
         return UpdateDesignerWorkspaceResult.from(savedDesigner, updatedWorkspace);

--- a/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateDesignerWorkspaceCommand.java
+++ b/peauty-designer-api/src/main/java/com/peauty/designer/business/designer/dto/UpdateDesignerWorkspaceCommand.java
@@ -44,7 +44,7 @@ public record UpdateDesignerWorkspaceCommand(
                 .build();
     }
 
-    public static List<License> toLicense(CreateDesignerWorkspaceCommand command) {
+    public static List<License> toLicense(UpdateDesignerWorkspaceCommand command) {
         return command.licenses().stream()
                 .map(imageUrl -> License.builder()
                         .licenseImageUrl(imageUrl)


### PR DESCRIPTION
## 📄 [PF-258] Workspace Update API for License Saving

Jira : [PEAUTY-258](https://multicampusuplus.atlassian.net/browse/PEAUTY-258?atlOrigin=eyJpIjoiNWZjNGUwNGU3ZGNkNGY5OGFhMTE0YjgxZmE0Mzk4NTYiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [x] 기능 추가/변경 설명
- [x] 버그 수정 설명
- [x] 문서 수정 설명

<!-- Pull Request의 설명을 추가하세요. -->
- 워크스페이스 업데이트 API 시, 라이센스 이미지가 저장안된 부분을 고쳤습니다.
- 추가적으로 생성에서 문제가 있는 부분도 고쳤습니다.

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.1MD
- Actual MD: 0.1MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [x] 코드가 잘 작동하는지 확인했나요?
- [x] 새로운 기능에 대한 테스트가 추가되었나요?
- [x] 문서가 업데이트되었나요?
