### PR TITLE
[PEUATY-263] refactor Logic removing reviewImages

### DIFF
--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/review/ReviewAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/review/ReviewAdapter.java
@@ -59,7 +59,7 @@ public class ReviewAdapter implements ReviewPort {
 
         Long reviewId = review.getId().map(Review.ID::value).orElseThrow(() ->
                 new PeautyException(PeautyResponseCode.NOT_FOUND_REVIEW));
-
+        // TODO: Patch, Put. 현재 방식은 Update가 아닌 기존 것을 삭제하고 새로운 것을 저장하는 로직이기 때문에 필히 코드 리팩토링이 필요함.
         // 기존 이미지를 삭제
         reviewImageRepository.deleteAllImagesByReviewId(reviewId);
 

--- a/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/review/ReviewAdapter.java
+++ b/peauty-customer-api/src/main/java/com/peauty/customer/implementaion/review/ReviewAdapter.java
@@ -56,6 +56,13 @@ public class ReviewAdapter implements ReviewPort {
 
     @Override
     public Review saveReview(Review review) {
+
+        Long reviewId = review.getId().map(Review.ID::value).orElseThrow(() ->
+                new PeautyException(PeautyResponseCode.NOT_FOUND_REVIEW));
+
+        // 기존 이미지를 삭제
+        reviewImageRepository.deleteAllImagesByReviewId(reviewId);
+
         ReviewEntity updatedReviewEntity = reviewRepository.save(
                 ReviewMapper.toReviewEntity(review)
         );

--- a/peauty-domain/src/main/java/com/peauty/domain/review/ContentGeneral.java
+++ b/peauty-domain/src/main/java/com/peauty/domain/review/ContentGeneral.java
@@ -11,7 +11,7 @@ public enum ContentGeneral {
     GOOD_SERVICE("서비스가 좋아요"),
     COME_AGAIN("다음에 또 오고 싶어요"),
     KIND("친절해요"),
-    GOOD_COST("서비스 좋아요"),
+    GOOD_COST("가성비 좋아요"),
     MYPICK("견적서대로 해줘요");
 
     private final String contentGeneralReview;

--- a/peauty-persistence/src/main/java/com/peauty/persistence/review/ReviewImageRepository.java
+++ b/peauty-persistence/src/main/java/com/peauty/persistence/review/ReviewImageRepository.java
@@ -10,4 +10,5 @@ public interface ReviewImageRepository extends JpaRepository<ReviewImageEntity, 
 
     List<ReviewImageEntity> findAllByReviewId(Long reviewId);
 
+    void deleteAllImagesByReviewId(Long reviewId);
 }


### PR DESCRIPTION
## 📄 [PEUATY-263] refactor Logic removing reviewImages

Jira : [PEAUTY-263](https://multicampusuplus.atlassian.net/browse/PEAUTY-263?atlOrigin=eyJpIjoiZmIyYmUwYWU2ZWJjNDQyYWE2OTg4YzQzZGY0OWIyZjAiLCJwIjoiaiJ9)

## ✨ 변경 사항
- [ ] 기능 추가/변경 설명
- [ ] 버그 수정 설명
- [ ] 문서 수정 설명

<!-- Pull Request의 설명을 추가하세요. -->

리뷰 업데이트 시에 기존 이미지를 제거하는 로직이 없었습니다.
그렇기 때문에 업데이트할 때마다 기존 사진에 더해서 이미지가 추가 됐는데
이 로직을 추가함으로써 업데이트할 때마다 기존 리뷰 사진을 삭제할 수 있습니다.

## 📅 작업 일정
<!-- 해당 작업을 수행하는데 예상했던 공수와 실제 소요되었던 공수를 기입해주세요. -->
- Expected MD: 0.1 MD
- Actual MD: 0.1 MD
### Difference reason (If correct, no need.)
- None.

## ✔️ 확인 사항

- [ ] 코드가 잘 작동하는지 확인했나요?
- [ ] 새로운 기능에 대한 테스트가 추가되었나요?
- [ ] 문서가 업데이트되었나요?
